### PR TITLE
Fixes two Wnonnull warnings

### DIFF
--- a/model/hd-us/closure/closure.c
+++ b/model/hd-us/closure/closure.c
@@ -137,8 +137,8 @@ void closure_init(parameters_t *params, /* Parameter data structure */
 	master->calc_closure = mixing_list[i].calc;
       }
     }
-  } else
-    strcpy(params->mixsc, "");
+  }
+
 
   /* Set the stability function if required */
   if (params->s_func != NULL) {

--- a/model/hd/closure/closure.c
+++ b/model/hd/closure/closure.c
@@ -137,8 +137,8 @@ void closure_init(parameters_t *params, /* Parameter data structure */
 	master->calc_closure = mixing_list[i].calc;
       }
     }
-  } else
-    strcpy(params->mixsc, "");
+  }
+
 
   /* Set the stability function if required */
   if (params->s_func != NULL) {


### PR DESCRIPTION
In both copies of closure.c, the statement

	strcpy(params->mixsc, "");

is only called if params->mixsc is NULL.  If that had ever
executed it should have segfaulted.  Removed the else clause
and the strcpy.

Applies cleanly to master and Wunused-variable.

Fixes #4 