### PR TITLE
Fixes several -Wsequence-point warnings

### DIFF
--- a/model/hd-us/slaves/windows.c
+++ b/model/hd-us/slaves/windows.c
@@ -5835,7 +5835,7 @@ window_t **win_data_build(master_t *master,   /* Master data         */
     windat[n]->regionid = windat[n]->regres = windat[n]->Vi = NULL;
     windat[n]->reefe1 = windat[n]->reefe2 = windat[n]->agetr = NULL;
     windat[n]->tr_adv = windat[n]->tr_hdif = windat[n]->tr_vdif = windat[n]->tr_ncon = NULL;
-    windat[n]->wave_stke1 = windat[n]->wave_stke1 = windat[n]->mono = NULL;
+    windat[n]->wave_stke1 = windat[n]->wave_stke2 = windat[n]->mono = NULL;
 
     for (tn = 0; tn < windat[n]->ntr; tn++) {
       if (strcmp("salt", master->trname[tn]) == 0) {
@@ -7539,7 +7539,7 @@ win_priv_t **win_consts_init(master_t *master,    /* Master data     */
     /* Set linear advection flags                                    */
     wincon[n]->dolin_u1 = wincon[n]->dolin_u2 = 0;
     wincon[n]->dobdry_u1 = wincon[n]->dobdry_u2 = 0;
-    wincon[n]->linmask_u1 = wincon[n]->linmask_u1 = NULL;
+    wincon[n]->linmask_u1 = wincon[n]->linmask_u2 = NULL;
     wincon[n]->obcmap = i_alloc_1d(window[n]->sgsiz);
     memset(wincon[n]->obcmap, 0, window[n]->sgsiz * sizeof(int));
     for (i = 0; i < window[n]->nobc; i++) {

--- a/model/hd/slaves/windows.c
+++ b/model/hd/slaves/windows.c
@@ -4958,7 +4958,7 @@ window_t **win_data_build(master_t *master, /* Model data structure */
     windat[n]->regionid = windat[n]->regres = windat[n]->Vi = NULL;
     windat[n]->reefe1 = windat[n]->reefe2 = windat[n]->agetr = NULL;
     windat[n]->tr_adv = windat[n]->tr_hdif = windat[n]->tr_vdif = windat[n]->tr_ncon = NULL;
-    windat[n]->wave_stke1 = windat[n]->wave_stke1 = NULL;
+    windat[n]->wave_stke1 = windat[n]->wave_stke2 = NULL;
 
     for (tn = 0; tn < windat[n]->ntr; tn++) {
       if (strcmp("salt", master->trname[tn]) == 0) {
@@ -6644,7 +6644,7 @@ win_priv_t **win_consts_init(master_t *master,    /* Master data     */
     /* Set linear advection flags                                    */
     wincon[n]->dolin_u1 = wincon[n]->dolin_u2 = 0;
     wincon[n]->dobdry_u1 = wincon[n]->dobdry_u2 = 0;
-    wincon[n]->linmask_u1 = wincon[n]->linmask_u1 = NULL;
+    wincon[n]->linmask_u1 = wincon[n]->linmask_u2 = NULL;
     wincon[n]->obcmap = i_alloc_1d(window[n]->sgsiz);
     memset(wincon[n]->obcmap, 0, window[n]->sgsiz * sizeof(int));
     for (i = 0; i < window[n]->nobc; i++) {

--- a/model/lib/ecology/parameter_defaults.c
+++ b/model/lib/ecology/parameter_defaults.c
@@ -47,7 +47,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].units = "Deg C";
   parameters[n].value[0] = 20.0;
   parameters[n].ref = " ";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Q10";
   parameters[n].desc  = "Temperature coefficient for rate parameters";
@@ -55,14 +55,14 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].units = "none";
   parameters[n].value[0] = 2.0;
   parameters[n].ref = " ";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "TKEeps";
   parameters[n].desc  = "Nominal rate of TKE dissipation in water column";
   parameters[n].sym   = "\\epsilon";
   parameters[n].units = "m2 s-3";
   parameters[n].value[0] = 1.0e-6;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "xco2_in_air";
   parameters[n].desc  = "Atmospheric CO2";
@@ -70,7 +70,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].units = "ppmv";
   parameters[n].value[0] = 396.48;
   parameters[n].ref = "Mean 2013 at Mauna Loa: http://co2now.org/current-co2/co2-now/";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "N2";
   parameters[n].desc  = "Concentration of dissolved N2";
@@ -78,7 +78,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "[\\mathrm{N}_2]_{gas}";
   parameters[n].value[0] = 2000.0;
   parameters[n].ref = "Robson et al. (2013)";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Light parameters */
 
@@ -114,7 +114,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].value[22] = 710.0;
   parameters[n].value[23] = 800.0;
   parameters[n].ref = "Approx. 20 nm resolution with 10 nm about 440 nm. PAR (400-700) is integral of bands 6-22.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "acdom443star";
   parameters[n].desc  = "DOC-specific absorption of CDOM 443 nm";
@@ -122,7 +122,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "k_{CDOM,443}";
   parameters[n].value[0] = 0.00013;
   parameters[n].ref = "Based on Feb 2011 GBR satellite data and modelled DOR_C";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "bphy";
   parameters[n].desc  = "Chl-specific scattering coef. for microalgae";
@@ -130,7 +130,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "b_{phy}";
   parameters[n].value[0] = 0.2;
   parameters[n].ref = "Typical microalgae value, Kirk (1994) Light and Photosynthesis in Aquatic ecosystems, Table 4.3";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "NtoCHL";
   parameters[n].desc  = "Nominal N:Chl a ratio in phytoplankton by weight";
@@ -138,7 +138,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "R_{N:Chl}";
   parameters[n].value[0] = 7;
   parameters[n].ref = "Represents a C:Chl ratio of 39.25, Baird et al. (2013) Limnol. Oceanogr. 58: 1215-1226.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Phytoplankton */
 
@@ -148,70 +148,70 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\mu_{PL}^{max}";
   parameters[n].value[0] = 1.4;
   parameters[n].ref = " ";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PLrad";
   parameters[n].desc  = "Radius of the large phytoplankton cells";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{PL}";
   parameters[n].value[0] = 4e-06;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PhyL_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, large phytoplankton";
   parameters[n].units = "d-1";
   parameters[n].sym   = "m_{L,PL}";
   parameters[n].value[0] = 0.1;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PhyL_mL_sed";
   parameters[n].desc  = "Natural (linear) mortality rate in sed., large phyto.";
   parameters[n].units = "d-1";
   parameters[n].sym   = "m_{L,PL,sed}";
   parameters[n].value[0] = 10.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PSumax";
   parameters[n].desc  = "Maximum growth rate of PS at Tref";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{PL}^{max}";
   parameters[n].value[0] = 1.6;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PSrad";
   parameters[n].desc  = "Radius of the small phytoplankton cells";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{PS}";
   parameters[n].value[0] = 1.e-06;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PhyS_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, small phyto.";
   parameters[n].units = "d-1";
   parameters[n].sym   = "m_{L,PS}";
   parameters[n].value[0] = 0.1;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PhyS_mL_sed";
   parameters[n].desc  = "Natural (linear) mortality rate in sed., small phyto.";
   parameters[n].units = "d-1";
   parameters[n].sym   = "m_{L,PS,sed}";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "MBumax";
   parameters[n].desc  = "Maximum growth rate of MB at Tref";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{MPB}^{max}";
   parameters[n].value[0] = 0.839;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "MBrad";
   parameters[n].desc  = "Radius of the MPB cells";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{MPB}";
   parameters[n].value[0] = 1e-05;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "MPB_mQ";
   parameters[n].desc  = "Natural (quadratic) mortality rate, MPB (in sed)";
@@ -219,7 +219,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "m_{Q,MPB}";
   parameters[n].value[0] = 0.0001;
   parameters[n].ref = "At steady-state, at mu = 0.1 d-1, indep. of temp, MPB_N ~ 0.1 / MPB_mQ = 250 mg N m-3";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PSxan2chl";
   parameters[n].desc  = "Ratio of xanthophyll to chl a of PS";
@@ -227,7 +227,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Theta_{xan2chl,PS}";
   parameters[n].value[0] = 0.51;
   parameters[n].ref = "CSIRO parameter library: GBR region";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PLxan2chl";
   parameters[n].desc  = "Ratio of xanthophyll to chl a of PL";
@@ -235,7 +235,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Theta_{xan2chl,PL}";
   parameters[n].value[0] = 0.81;
   parameters[n].ref = "CSIRO parameter library: GBR region";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "MBxan2chl";
   parameters[n].desc  = "Ratio of xanthophyll to chl a of MPB";
@@ -243,7 +243,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Theta_{xan2chl,MPB}";
   parameters[n].value[0] = 0.81;
   parameters[n].ref = "CSIRO parameter library: GBR region WC values";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Trichodesmium */
   parameters[n].name  = "Tricho_umax";
@@ -251,28 +251,28 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{MPB}^{max}";
   parameters[n].value[0] = 0.24;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Tricho_rad";
   parameters[n].desc  = "Radius of Trichodesmium colonies";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{MPB}";
   parameters[n].value[0] = 0.000005;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Tricho_Sh";
   parameters[n].desc  = "Sherwood number for the Tricho dimensionless";
   parameters[n].units = "none";
   parameters[n].sym   = "Sh_{Tricho}";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Tricho_mL";
   parameters[n].desc  = "Linear mortality for Tricho in sediment";
   parameters[n].units = "d-1";
   parameters[n].sym   = "m_{L,Tricho}";
   parameters[n].value[0] = 0.140000;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Tricho_mQ";
   parameters[n].desc  = "Quadratic mortality for Tricho due to phages in wc";
@@ -280,14 +280,14 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "m_{Q,Tricho}";
   parameters[n].value[0] = 0.1000;
   parameters[n].ref = "At steady-state, indep. of temp, Tricho_N ~ Tricho_umax / Tricho_mQ = 0.27 / 0.405 = 0.7 mg N m-3 ~ 0.1 mg Chl m-3";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Tricho_crit";
   parameters[n].desc  = "Critical Tricho above which quadratic mortality applies";
   parameters[n].units = "mg N m-3";
   parameters[n].value[0] = 0.0002000;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "p_min";
   parameters[n].desc  = "Minimum density of Trichodesmium";
@@ -295,7 +295,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\rho_{min,Tricho}";
   parameters[n].value[0] = 990.000000;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "p_max";
   parameters[n].desc  = "Maximum density of Trichodesmium";
@@ -303,7 +303,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\rho_{max,Tricho}";
   parameters[n].value[0] = 1026.000000;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "DINcrit";
   parameters[n].desc  = "DIN conc below which Tricho N fixes ";
@@ -311,7 +311,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "DIN_{crit}";
   parameters[n].value[0] = 10.0;
   parameters[n].ref = "Lower end of Robson et al., (2013) 4-20 mg N m-3";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Trichoxan2chl";
   parameters[n].desc  = "Ratio of xanthophyll to chl a of Trichodesmium";
@@ -319,7 +319,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Theta_{xan2chl,Tricho}";
   parameters[n].value[0] = 0.5;
   parameters[n].ref = "Subramaniam (1999) LO 44:608-617. Actually redder pigment than xanthophyll.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "C2Chlmin";
   parameters[n].desc  = "Minimum carbon to chlorophyll a ratio";
@@ -327,7 +327,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\theta_{min}";
   parameters[n].value[0] = 20.0;
   parameters[n].ref = "From HPLC in Sathyendranath et al., 2009 MEPS 383,73-84";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
 
   /* Zooplankton */
@@ -336,54 +336,54 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{max}^{ZS}";
   parameters[n].value[0] = 4.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZSrad";
   parameters[n].desc  = "Radius of the small zooplankton cells";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{ZS}";
   parameters[n].value[0] = 5.0e-06;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZSswim";
   parameters[n].desc  = "Swimming velocity for small zooplankton";
   parameters[n].units = "m s-1";
   parameters[n].sym   = "U_{ZS}";
   parameters[n].value[0] = 2.0e-4;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZSmeth";
   parameters[n].desc  = "Grazing technique of small zooplankton";
   parameters[n].units = "none";
   parameters[n].stringvalue = "rect";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZLumax";
   parameters[n].desc  = "Maximum growth rate of ZL at Tref";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{max}^{ZL}";
   parameters[n].value[0] = 1.33;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZLrad";
   parameters[n].desc  = "Radius of the large zooplankton cells";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{ZL}";
   parameters[n].value[0] = 3.20e-04;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZLswim";
   parameters[n].desc  = "Swimming velocity for large zooplankton";
   parameters[n].units = "m s-1";
   parameters[n].sym   = "U_{ZL}";
   parameters[n].value[0] = 3.0e-3;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZLmeth";
   parameters[n].desc  = "Grazing technique of large zooplankton";
   parameters[n].units = "none";
   parameters[n].stringvalue = "rect";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZL_E";
   parameters[n].desc  = "Growth efficiency, large zooplankton";
@@ -392,7 +392,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.426;
   parameters[n].stderr = 0.0179;
   parameters[n].ref = "Baird and Suthers, 2007 from Hansen et al (1997) LO 42: 687-704";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZS_E";
   parameters[n].desc  = "Growth efficiency, small zooplankton";
@@ -401,49 +401,49 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.462;
   parameters[n].stderr = 0.0266;
   parameters[n].ref = "Baird and Suthers, 2007 from Hansen et al (1997) LO 42: 687-704";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZL_mQ";
   parameters[n].desc  = "Natural (quadratic) mortality rate, large zooplankton";
   parameters[n].sym   = "m_{Q,ZL}";
   parameters[n].units = "d-1 (mg N m-3)-1";
   parameters[n].value[0] = 0.012;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZS_mQ";
   parameters[n].desc  = "Natural (quadratic) mortality rate, small zooplankton";
   parameters[n].units = "d-1 (mg N m-3)-1";
   parameters[n].sym   = "m_{Q,ZS}";
   parameters[n].value[0] = 0.007;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZL_FDG";
   parameters[n].desc  = "Fraction of growth inefficiency lost to detritus, large zoo.";
   parameters[n].units = "none";
   parameters[n].sym   = "\\gamma_{ZL}";
   parameters[n].value[0] = 0.5;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZL_FDM";
   parameters[n].desc  = "Fraction of mortality lost to detritus, large zoo.";
   parameters[n].units = "none";
   parameters[n].sym   = "N/A";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZS_FDG";
   parameters[n].desc  = "Fraction of growth inefficiency lost to detritus, small zoo.";
   parameters[n].units = "none";
   parameters[n].sym   = "\\gamma_{ZS}";
   parameters[n].value[0] = 0.5;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZS_FDM";
   parameters[n].desc  = "Fraction of mortality lost to detritus, small zooplankton";
   parameters[n].units = "none";
   parameters[n].sym   = "N/A";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Remineralisation */
   parameters[n].name  = "F_LD_RD";
@@ -451,56 +451,56 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].units = "none";
   parameters[n].sym   = "\\zeta_{Red}";
   parameters[n].value[0] = 0.19;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "F_LD_DOM";
   parameters[n].desc  = "Fraction of labile detritus converted to DOM";
   parameters[n].units = "none";
   parameters[n].sym   = "\\vartheta_{Red}";
   parameters[n].value[0] = 0.1;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "F_RD_DOM";
   parameters[n].desc  = "fraction of refractory detritus that breaks down to DOM";
   parameters[n].units = "none";
   parameters[n].sym   = "\\vartheta_{Ref}";
   parameters[n].value[0] = 0.05;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_DetPL";
   parameters[n].desc  = "Breakdown rate of labile detritus at 106:16:1";
   parameters[n].units = "d-1";
   parameters[n].sym   = "r_{Red}";
   parameters[n].value[0] = 0.04;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_DetBL";
   parameters[n].desc  = "Breakdown rate of labile detritus at 550:30:1";
   parameters[n].units = "d-1";
   parameters[n].sym   = "r_{Atk}";
   parameters[n].value[0] = 0.001;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_RD";
   parameters[n].desc  = "Breakdown rate of refractory detritus";
   parameters[n].units = "d-1";
   parameters[n].sym   = "r_{R}";
   parameters[n].value[0] = 0.001;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_DOM";
   parameters[n].desc  = "Breakdown rate of dissolved organic matter";
   parameters[n].units = "d-1";
   parameters[n].sym   = "r_{O}";
   parameters[n].value[0] = 0.0001;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Plank_resp";
   parameters[n].desc  = "Respiration as a fraction of umax";
   parameters[n].units = "none";
   parameters[n].sym   = "\\phi";
   parameters[n].value[0] = 0.025;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Sediment parameters */
 
@@ -509,98 +509,98 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].units = "mg O m-3";
   parameters[n].sym   = "K_{OA}";
   parameters[n].value[0] = 256.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_nit_wc";
   parameters[n].desc  = "Maximum nitrification rate in water column";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\tau_{nit,wc}";
   parameters[n].value[0] = 0.1;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_nit_sed";
   parameters[n].desc  = "Maximum nitrification rate in water sediment";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\tau_{nit,sed}";
   parameters[n].value[0] = 20.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "KO_nit";
   parameters[n].desc  = "Oxygen half-saturation for nitrification";
   parameters[n].units = "mg O m-3";
   parameters[n].sym   = "K_{\\mathrm{O}_2,nit}";
   parameters[n].value[0] = 500.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Pads_r";
   parameters[n].desc  = "Rate at which P reaches adsorbed/desorbed equilibrium";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\tau_{Pabs}";
   parameters[n].value[0] = 0.04;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Pads_Kwc";
   parameters[n].desc  = "Freundlich Isothermic Const P adsorption to TSS in wc";
   parameters[n].units = "mg P kg TSS-1";
   parameters[n].sym   = "k_{Pads,wc}";
   parameters[n].value[0] = 30.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Pads_Ksed";
   parameters[n].desc  = "Freundlich Isothermic Const P adsorption to TSS in sed";
   parameters[n].units = "mg P kg TSS-1";
   parameters[n].sym   = "k_{Pads,sed}";
   parameters[n].value[0] = 74.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Pads_KO";
   parameters[n].desc  = "Oxygen half-saturation for P adsorption";
   parameters[n].units = "mg O m-3";
   parameters[n].sym   = "K_{\\mathrm{O}_2,abs}";
   parameters[n].value[0] = 2000.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Pads_exp";
   parameters[n].desc  = "Exponent for Freundlich Isotherm";
   parameters[n].units = "none";
   parameters[n].sym   = "N/A";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_den";
   parameters[n].desc  = "Maximum denitrification rate";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\tau_{denit}";
   parameters[n].value[0] = 1.0;   // 5.0 in B1p9.
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "KO_den";
   parameters[n].desc  = "Oxygen half-saturation constant for denitrification";
   parameters[n].units = "mg O m-3";
   parameters[n].sym   = "K_{\\mathrm{O}_2,denit}";
   parameters[n].value[0] = 10000.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_immob_PIP";
   parameters[n].desc  = "Rate of conversion of PIP to immobilised PIP";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\tau_{Pimm}";
   parameters[n].value[0] = 0.0012;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "EpiDiffCoeff";
   parameters[n].desc  = "Sediment-water diffusion coefficient";
   parameters[n].units = "m2 s-1";
   parameters[n].sym   = "D";
   parameters[n].value[0] = 3e-7;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "EpiDiffDz";
   parameters[n].desc  = "Thickness of diffusive layer";
   parameters[n].units = "m";
   parameters[n].sym   = "h";
   parameters[n].value[0] = 0.0065;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   /* Marcroalgae */
   parameters[n].name  = "MAumax";
@@ -608,28 +608,28 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{MA}^{max}";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "MA_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, macroalgae";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\zeta_{MA}";
   parameters[n].value[0] = 0.01;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "MAleafden";
   parameters[n].desc  = "Nitrogen-specific leaf area of macroalgae";
   parameters[n].units = "m2 g N-1";
   parameters[n].sym   = "\\Omega_{MA}";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Benth_resp";
   parameters[n].desc  = "Respiration as a fraction of umax";
   parameters[n].units = "none";
   parameters[n].sym   = "\\phi";
   parameters[n].value[0] = 0.025;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Seagrass parameters - Zostera */
   parameters[n].name  = "SGumax";
@@ -638,7 +638,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\mu_{SG}^{max}";
   parameters[n].value[0] = 0.4;
   parameters[n].ref = "x2 nighttime, x2 for roots.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name  = "SG_KN";
   parameters[n].desc  = "Half-saturation of SG N uptake in SED";
@@ -646,7 +646,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "K_{SG,N}";
   parameters[n].value[0] = 420.0;
   parameters[n].ref = "Lee and Dunton (1999) 1204-1215. Table 3 Zostera";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SG_KP";
   parameters[n].desc  = "Half-saturation of SG P uptake in SED";
@@ -654,7 +654,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "K_{SG,P}";
   parameters[n].value[0] = 96.0;
   parameters[n].ref = "Gras et al. (2003) Aquatic Botany 76:299-315. Thalassia testudinum.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SG_mL";
   parameters[n].desc  = "Natural (linear) mortality rate aboveground seagrass";
@@ -663,7 +663,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.03;
   parameters[n].stderr = 0.001;
   parameters[n].ref = "Fourquean et al.( 2003) Chem. Ecol. 19: 373-390.Thalassia leaves with one component decay";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGROOT_mL";
   parameters[n].desc  = "Natural (linear) mortality rate belowground seagrass";
@@ -672,7 +672,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.004;
   parameters[n].stderr = 0.0002;
   parameters[n].ref = "Fourquean et al. (2003) Chem. Ecol. 19: 373-390. Thalassia roots with one component decay";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGfrac";
   parameters[n].desc  = "Fraction (target) of SG biomass below-ground";
@@ -680,7 +680,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "f_{below,SG}";
   parameters[n].value[0] = 0.75;
   parameters[n].ref = "Babcock (2015) Zostera capricornii.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGtransrate";
   parameters[n].desc  = "Time scale for seagrass translocation";
@@ -688,7 +688,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{tran,SG}";
   parameters[n].value[0] = 0.0333;
   parameters[n].ref = "Loosely based on Zostera marine Kaldy et al., 2013 MEPS 487:27-39";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGleafden";
   parameters[n].desc  = "Nitrogen-specific leaf area of seagrass";
@@ -696,7 +696,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Omega_{SG}";
   parameters[n].value[0] = 1.5;
   parameters[n].ref = "Zostera capricornia: leaf dimensions Kemp et al (1987) Mar Ecol. Prog. Ser. 41:79-86.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGseedfrac";
   parameters[n].desc  = "Seagrass seed biomass as fraction of 63 % cover";
@@ -704,7 +704,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "f_{seed,SG}";
   parameters[n].value[0] = 0.01;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGorient";
   parameters[n].desc  = "Sine of nadir Zostera canopy bending angle";
@@ -712,7 +712,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\sin \\beta_{blade,SG}";
   parameters[n].value[0] = 0.5;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGmlr";
   parameters[n].desc  = "Compensation irradiance for Zostera";
@@ -720,7 +720,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "E_{comp,SG}";
   parameters[n].value[0] = 4.5;
   parameters[n].ref = "Chartrand (2012) Tech report.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGrootdepth";
   parameters[n].desc  = "Maximum depth for Zostera roots";
@@ -728,7 +728,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "z_{root,SG}";
   parameters[n].value[0] = -0.15;
   parameters[n].ref = "Roberts (1993) Aust. J. Mar. Fresh. Res. 44:85-100.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SG_tau_critical";
   parameters[n].desc  = "Critical shear stress for SG loss";
@@ -736,7 +736,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{SG,shear}";
   parameters[n].value[0] = 1.0;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SG_tau_time";
   parameters[n].desc  = "Time-scale for critical shear stress for SG loss";
@@ -744,7 +744,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{SG,time}";
   parameters[n].value[0] = 43200.0;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Seagrass parameters - Halophila */
   parameters[n].name  = "SGHumax";
@@ -753,21 +753,21 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\mu_{SGH}^{max}";
   parameters[n].value[0] = 0.4;
   parameters[n].ref = "x2 nighttime, x2 for roots.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGH_KN";
   parameters[n].desc  = "Half-saturation of SGH N uptake in SED";
   parameters[n].units = "mg N m-3";
   parameters[n].sym   = "K_{SGH,N}";
   parameters[n].value[0] = 420.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGH_KP";
   parameters[n].desc  = "Half-saturation of SGH P uptake in SED";
   parameters[n].units = "mg P m-3";
   parameters[n].sym   = "K_{SGH,P}";
   parameters[n].value[0] = 96.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHleafden";
   parameters[n].desc  = "Nitrogen-specific leaf area of SGH"; 
@@ -775,7 +775,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Omega_{SGH}";
   parameters[n].value[0] = 1.9;
   parameters[n].ref = "Halophila ovalis: leaf dimensions from Vermaat et al. (1995)";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGH_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, aboveground SGH";
@@ -784,7 +784,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.06;
   parameters[n].stderr = 0.001;
   parameters[n].ref = "Fourquean et al.(2003) Chem. Ecol. 19: 373-390.Thalassia leaves with one component decay";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHROOT_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, belowground SGH";
@@ -793,7 +793,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.004;
   parameters[n].stderr = 0.0002;
   parameters[n].ref = "Fourquean et al. (2003) Chem. Ecol. 19: 373-390. Thalassia roots with one component decay";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHfrac";
   parameters[n].desc  = "Fraction (target) of SGH biomass below-ground";
@@ -801,7 +801,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "f_{below,SGH}";
   parameters[n].value[0] = 0.5;
   parameters[n].ref = "Babcock 2015, Halophila ovalis";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHtransrate";
   parameters[n].desc  = "Time scale for Halophila translocation";
@@ -809,7 +809,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{tran,SGH}";
   parameters[n].value[0] = 0.0333;
   parameters[n].ref = "Loosely based on Zostera marine Kaldy et al., 2013 MEPS 487:27-39";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHseedfrac";
   parameters[n].desc  = "Halophila seed biomass as fraction of 63 % cover";
@@ -817,7 +817,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "f_{seed,SGH}";
   parameters[n].value[0] = 0.01;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHorient";
   parameters[n].desc  = "Sine of nadir Halophila canopy bending angle";
@@ -825,7 +825,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\sin \\beta_{blade,SGH}";
   parameters[n].value[0] = 1.0;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHmlr";
   parameters[n].desc  = "Compensation irradiance for Halophila";
@@ -833,7 +833,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "E_{comp,SGH}";
   parameters[n].value[0] = 2.0;
   parameters[n].ref = "Longstaff 2003 UQ PhD thesis";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHrootdepth";
   parameters[n].desc  = "Maximum depth for Halophila roots";
@@ -841,7 +841,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "z_{root,SGH}";
   parameters[n].value[0] = -0.08;
   parameters[n].ref = "Roberts (1993) Aust. J. Mar. Fresh. Res. 44:85-100.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGH_tau_critical";
   parameters[n].desc  = "Critical shear stress for SGH loss";
@@ -849,7 +849,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{SGH,shear}";
   parameters[n].value[0] = 1.0;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGH_tau_time";
   parameters[n].desc  = "Time-scale for critical shear stress for SGH loss";
@@ -857,7 +857,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{SGH,time}";
   parameters[n].value[0] = 43200.0;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
 
   /* Seagrass parameters - Deep */
@@ -867,21 +867,21 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\mu_{SGD}^{max}";
   parameters[n].value[0] = 0.4;
   parameters[n].ref = "x2 nighttime, x2 for roots.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGD_KN";
   parameters[n].desc  = "Half-saturation of SGD N uptake in SED";
   parameters[n].units = "mg N m-3";
   parameters[n].sym   = "K_{SGD,N}";
   parameters[n].value[0] = 420.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGD_KP";
   parameters[n].desc  = "Half-saturation of SGD P uptake in SED";
   parameters[n].units = "mg P m-3";
   parameters[n].sym   = "K_{SGD,P}";
   parameters[n].value[0] = 96.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDleafden";
   parameters[n].desc  = "Nitrogen-specific leaf area of SGD"; 
@@ -889,7 +889,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Omega_{SGD}";
   parameters[n].value[0] = 1.9;
   parameters[n].ref = "Halophila ovalis: leaf dimensions from Vermaat et al. (1995)";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGD_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, aboveground SGD";
@@ -898,7 +898,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.06;
   parameters[n].stderr = 0.001;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDROOT_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, belowground SGD";
@@ -907,7 +907,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.004;
   parameters[n].stderr = 0.00002;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDfrac";
   parameters[n].desc  = "Fraction (target) of SGD biomass below-ground";
@@ -915,7 +915,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "f_{below,SGD}";
   parameters[n].value[0] = 0.25;
   parameters[n].ref = "Duarte (1999) Aquatic Biol. 65: 159-174, Halophila ovalis.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDtransrate";
   parameters[n].desc  = "Time scale for deep SG translocation";
@@ -923,7 +923,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{tran,SGD}";
   parameters[n].value[0] = 0.0333;
   parameters[n].ref = "Loosely based on Zostera marine Kaldy et al., 2013 MEPS 487:27-39";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDseedfrac";
   parameters[n].desc  = "Deep SG seed biomass as fraction of 63 % cover";
@@ -931,7 +931,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "f_{seed,SGD}";
   parameters[n].value[0] = 0.01;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDorient";
   parameters[n].desc  = "Sine of nadir deep SG canopy bending angle";
@@ -939,7 +939,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\sin \\beta_{blade,SGD}";
   parameters[n].value[0] = 1.0;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDmlr";
   parameters[n].desc  = "Compensation irradiance for deep SG";
@@ -947,7 +947,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "E_{comp,SGD}";
   parameters[n].value[0] = 1.5;
   parameters[n].ref = "Chartrand (2017) Tech report.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDrootdepth";
   parameters[n].desc  = "Maximum depth for deep SG roots";
@@ -955,7 +955,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "z_{root,SGD}";
   parameters[n].value[0] = -0.05;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGD_tau_critical";
   parameters[n].desc  = "Critical shear stress for deep SG loss";
@@ -963,7 +963,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{SGD,shear}";
   parameters[n].value[0] = 1.0;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGD_tau_time";
   parameters[n].desc  = "Time-scale for shear stress for deep SG loss";
@@ -971,7 +971,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{SGD,time}";
   parameters[n].value[0] = 43200.0;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Corals */
   parameters[n].name  = "dissCaCO3_sed";
@@ -979,7 +979,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].units = "mmol C m-2 s-1";
   parameters[n].sym   = "d_{sand}";
   parameters[n].value[0] = 0.001;   // 0.007 in B1p9
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   parameters[n].ref = "Anthony et al. (2013), Biogeosciences 10:4897-4909, Fig 5E: -1 2 3 6  mmol m-2 h-1";
 
   parameters[n].name  = "CHarea";
@@ -987,7 +987,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].units = "m2 m-2";
   parameters[n].sym   = "A_{CH}";
   parameters[n].value[0] = 0.1;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   parameters[n].ref = "Heron Island for on 4 km model.";
 
   parameters[n].name  = "CHpolypden";
@@ -995,49 +995,49 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].units = "m2 g N-1";
   parameters[n].sym   = "\\Omega_{CH}";
   parameters[n].value[0] = 2.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CHumax";
   parameters[n].desc  = "Max. growth rate of Coral at Tref";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{CH}^{max}";
   parameters[n].value[0] = 0.05;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CSumax";
   parameters[n].desc  = "Max. growth rate of zooxanthellae at Tref";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{CS}^{max}";
   parameters[n].value[0] = 0.4;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CSrad";
   parameters[n].desc  = "Radius of the zooxanthellae ";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{CS}";
   parameters[n].value[0] = 5e-06;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CHmort";
   parameters[n].desc  = "Quadratic mortality rate of coral polyp ";
   parameters[n].units = "(g N m-2)-1 d-1";
   parameters[n].sym   = "\\zeta_{CH}";
   parameters[n].value[0] = 0.01;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CSmort";
   parameters[n].desc  = "Linear mortality rate of zooxanthellae ";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\zeta_{CS}";
   parameters[n].value[0] = 0.04;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CHremin";
   parameters[n].desc  = "Fraction of coral host death translocated.";
   parameters[n].units = "-";
   parameters[n].sym   = "f_{remin}";
   parameters[n].value[0] = 0.5;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Splank";
   parameters[n].desc  = "Rate coefficent for particle uptake by corals";
@@ -1045,7 +1045,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "S_{part}";
   parameters[n].value[0] = 3.0;
   parameters[n].ref = "Ribes and Atkinson (2007) Coral Reefs 26: 413-421";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "k_day_coral";
   parameters[n].desc  = "Maximum daytime coral calcification";
@@ -1053,7 +1053,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "k_{day}";
   parameters[n].value[0] = 0.0132;
   parameters[n].ref = "Anthony et al. (2013), Biogeosciences 10:4897-4909, Fig 5A: 50, 50, 35 55 mmol m-2 h-1 for Acropora aspera n=4";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "k_night_coral";
   parameters[n].desc  = "Maximum nightime coral calcification";
@@ -1061,7 +1061,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "k_{night}";
   parameters[n].value[0] = 0.0069;
   parameters[n].ref = "Anthony et al. (2013), Biogeosciences 10:4897-4909, Fig 5A: 20, 30, 20, 30  mmol m-2 h-1 for Acropora aspera n=4";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "dissCaCO3_shelf";
   parameters[n].desc  = "Carbonate sediment dissolution rate on shelf";
@@ -1069,7 +1069,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "d_{shelf}";
   parameters[n].value[0] = 0.0001;
   parameters[n].ref = "Cyronak, T. et al., LO 58:131-143. Heron Island study.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ageing_decay";
   parameters[n].desc  = "Age tracer growth rate per day";
@@ -1077,7 +1077,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "n/a";
   parameters[n].value[0] = 1.0;
   parameters[n].ref = "EMS manual";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "anti_ageing_decay";
   parameters[n].desc  = "Age tracer decay rate per day outside source";
@@ -1085,7 +1085,7 @@ void eco_params_bgc2p0(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Phi";
   parameters[n].value[0] = 0.1;
   parameters[n].ref = "EMS manual";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
 
   /* Assign acutal number of parameters */
@@ -1111,7 +1111,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].units = "Deg C";
   parameters[n].value[0] = 20.0;
   parameters[n].ref = " ";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Q10";
   parameters[n].desc  = "Temperature coefficient for rate parameters";
@@ -1119,14 +1119,14 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].units = "none";
   parameters[n].value[0] = 2.0;
   parameters[n].ref = " ";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "TKEeps";
   parameters[n].desc  = "Nominal rate of TKE dissipation in water column";
   parameters[n].sym   = "\\epsilon";
   parameters[n].units = "m2 s-3";
   parameters[n].value[0] = 1.0e-6;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   // parameters[n].name  = "xco2_in_air";
   // parameters[n].desc  = "Atmospheric CO2";
@@ -1134,7 +1134,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   // parameters[n].units = "ppmv";
   // parameters[n].value[0] = 396.48;
   // parameters[n].ref = "Mean 2013 at Mauna Loa: http://co2now.org/current-co2/co2-now/";
-  // parameters[n].index = n++;
+  // parameters[n].index = n; n++;
 
   parameters[n].name  = "N2";
   parameters[n].desc  = "Concentration of dissolved N2";
@@ -1142,7 +1142,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "[\\mathrm{N}_2]_{gas}";
   parameters[n].value[0] = 2000.0;
   parameters[n].ref = "Robson et al. (2013)";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Light parameters */
 
@@ -1178,7 +1178,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].value[22] = 710.0;
   parameters[n].value[23] = 800.0;
   parameters[n].ref = "Approx. 20 nm resolution with 10 nm about 440 nm. PAR (400-700) is integral of bands 6-22.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "acdom443star";
   parameters[n].desc  = "DOC-specific absorption of CDOM 443 nm";
@@ -1186,7 +1186,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "k_{CDOM,443}";
   parameters[n].value[0] = 0.00013;
   parameters[n].ref = "Based on Feb 2011 GBR satellite data and modelled DOR_C";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "bphy";
   parameters[n].desc  = "Chl-specific scattering coef. for microalgae";
@@ -1194,7 +1194,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "b_{phy}";
   parameters[n].value[0] = 0.2;
   parameters[n].ref = "Typical microalgae value, Kirk (1994) Light and Photosynthesis in Aquatic ecosystems, Table 4.3";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "NtoCHL";
   parameters[n].desc  = "Nominal N:Chl a ratio in phytoplankton by weight";
@@ -1202,7 +1202,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "R_{N:Chl}";
   parameters[n].value[0] = 7;
   parameters[n].ref = "Represents a C:Chl ratio of 39.25, Baird et al. (2013) Limnol. Oceanogr. 58: 1215-1226.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Phytoplankton */
 
@@ -1212,70 +1212,70 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\mu_{PL}^{max}";
   parameters[n].value[0] = 1.4;
   parameters[n].ref = " ";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PLrad";
   parameters[n].desc  = "Radius of the large phytoplankton cells";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{PL}";
   parameters[n].value[0] = 4e-06;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PhyL_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, large phytoplankton";
   parameters[n].units = "d-1";
   parameters[n].sym   = "m_{L,PL}";
   parameters[n].value[0] = 0.1;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PhyL_mL_sed";
   parameters[n].desc  = "Natural (linear) mortality rate in sed., large phyto.";
   parameters[n].units = "d-1";
   parameters[n].sym   = "m_{L,PL,sed}";
   parameters[n].value[0] = 10.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PSumax";
   parameters[n].desc  = "Maximum growth rate of PS at Tref";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{PL}^{max}";
   parameters[n].value[0] = 1.6;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PSrad";
   parameters[n].desc  = "Radius of the small phytoplankton cells";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{PS}";
   parameters[n].value[0] = 1.e-06;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PhyS_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, small phyto.";
   parameters[n].units = "d-1";
   parameters[n].sym   = "m_{L,PS}";
   parameters[n].value[0] = 0.1;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PhyS_mL_sed";
   parameters[n].desc  = "Natural (linear) mortality rate in sed., small phyto.";
   parameters[n].units = "d-1";
   parameters[n].sym   = "m_{L,PS,sed}";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "MBumax";
   parameters[n].desc  = "Maximum growth rate of MB at Tref";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{MPB}^{max}";
   parameters[n].value[0] = 0.839;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "MBrad";
   parameters[n].desc  = "Radius of the MPB cells";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{MPB}";
   parameters[n].value[0] = 1e-05;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "MPB_mQ";
   parameters[n].desc  = "Natural (quadratic) mortality rate, MPB (in sed)";
@@ -1283,7 +1283,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "m_{Q,MPB}";
   parameters[n].value[0] = 0.0001;
   parameters[n].ref = "At steady-state, at mu = 0.1 d-1, indep. of temp, MPB_N ~ 0.1 / MPB_mQ = 250 mg N m-3";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PSxan2chl";
   parameters[n].desc  = "Ratio of xanthophyll to chl a of PS";
@@ -1291,7 +1291,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Theta_{xan2chl,PS}";
   parameters[n].value[0] = 0.51;
   parameters[n].ref = "CSIRO parameter library: GBR region";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PLxan2chl";
   parameters[n].desc  = "Ratio of xanthophyll to chl a of PL";
@@ -1299,7 +1299,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Theta_{xan2chl,PL}";
   parameters[n].value[0] = 0.81;
   parameters[n].ref = "CSIRO parameter library: GBR region";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "MBxan2chl";
   parameters[n].desc  = "Ratio of xanthophyll to chl a of MPB";
@@ -1307,7 +1307,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Theta_{xan2chl,MPB}";
   parameters[n].value[0] = 0.81;
   parameters[n].ref = "CSIRO parameter library: GBR region WC values";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Trichodesmium */
   parameters[n].name  = "Tricho_umax";
@@ -1315,28 +1315,28 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{MPB}^{max}";
   parameters[n].value[0] = 0.20;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Tricho_rad";
   parameters[n].desc  = "Radius of Trichodesmium colonies";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{MPB}";
   parameters[n].value[0] = 0.000005;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Tricho_Sh";
   parameters[n].desc  = "Sherwood number for the Tricho dimensionless";
   parameters[n].units = "none";
   parameters[n].sym   = "Sh_{Tricho}";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Tricho_mL";
   parameters[n].desc  = "Linear mortality for Tricho in sediment";
   parameters[n].units = "d-1";
   parameters[n].sym   = "m_{L,Tricho}";
   parameters[n].value[0] = 0.10000;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Tricho_mQ";
   parameters[n].desc  = "Quadratic mortality for Tricho due to phages in wc";
@@ -1344,14 +1344,14 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "m_{Q,Tricho}";
   parameters[n].value[0] = 0.1000;
   parameters[n].ref = "At steady-state, indep. of temp, Tricho_N ~ Tricho_umax / Tricho_mQ = 0.27 / 0.405 = 0.7 mg N m-3 ~ 0.1 mg Chl m-3";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Tricho_crit";
   parameters[n].desc  = "Critical Tricho above which quadratic mortality applies";
   parameters[n].units = "mg N m-3";
   parameters[n].value[0] = 0.0002000;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "p_min";
   parameters[n].desc  = "Minimum density of Trichodesmium";
@@ -1359,7 +1359,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\rho_{min,Tricho}";
   parameters[n].value[0] = 900.000000;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "p_max";
   parameters[n].desc  = "Maximum density of Trichodesmium";
@@ -1367,7 +1367,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\rho_{max,Tricho}";
   parameters[n].value[0] = 1050.000000;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "DINcrit";
   parameters[n].desc  = "DIN conc below which Tricho N fixes ";
@@ -1375,7 +1375,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "DIN_{crit}";
   parameters[n].value[0] = 10.0;
   parameters[n].ref = "Lower end of Robson et al., (2013) 4-20 mg N m-3";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Trichoxan2chl";
   parameters[n].desc  = "Ratio of xanthophyll to chl a of Trichodesmium";
@@ -1383,7 +1383,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Theta_{xan2chl,Tricho}";
   parameters[n].value[0] = 0.5;
   parameters[n].ref = "Subramaniam (1999) LO 44:608-617. Actually redder pigment than xanthophyll.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "C2Chlmin";
   parameters[n].desc  = "Minimum carbon to chlorophyll a ratio";
@@ -1391,7 +1391,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\theta_{min}";
   parameters[n].value[0] = 20.0;
   parameters[n].ref = "From HPLC in Sathyendranath et al., 2009 MEPS 383,73-84";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
 
   /* Zooplankton */
@@ -1400,54 +1400,54 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{max}^{ZS}";
   parameters[n].value[0] = 4.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZSrad";
   parameters[n].desc  = "Radius of the small zooplankton cells";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{ZS}";
   parameters[n].value[0] = 5.0e-06;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZSswim";
   parameters[n].desc  = "Swimming velocity for small zooplankton";
   parameters[n].units = "m s-1";
   parameters[n].sym   = "U_{ZS}";
   parameters[n].value[0] = 2.0e-4;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZSmeth";
   parameters[n].desc  = "Grazing technique of small zooplankton";
   parameters[n].units = "none";
   parameters[n].stringvalue = "rect";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZLumax";
   parameters[n].desc  = "Maximum growth rate of ZL at Tref";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{max}^{ZL}";
   parameters[n].value[0] = 1.33;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZLrad";
   parameters[n].desc  = "Radius of the large zooplankton cells";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{ZL}";
   parameters[n].value[0] = 3.20e-04;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZLswim";
   parameters[n].desc  = "Swimming velocity for large zooplankton";
   parameters[n].units = "m s-1";
   parameters[n].sym   = "U_{ZL}";
   parameters[n].value[0] = 3.0e-3;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZLmeth";
   parameters[n].desc  = "Grazing technique of large zooplankton";
   parameters[n].units = "none";
   parameters[n].stringvalue = "rect";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZL_E";
   parameters[n].desc  = "Growth efficiency, large zooplankton";
@@ -1456,7 +1456,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.426;
   parameters[n].stderr = 0.0179;
   parameters[n].ref = "Baird and Suthers, 2007 from Hansen et al (1997) LO 42: 687-704";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZS_E";
   parameters[n].desc  = "Growth efficiency, small zooplankton";
@@ -1465,49 +1465,49 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.462;
   parameters[n].stderr = 0.0266;
   parameters[n].ref = "Baird and Suthers, 2007 from Hansen et al (1997) LO 42: 687-704";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZL_mQ";
   parameters[n].desc  = "Natural (quadratic) mortality rate, large zooplankton";
   parameters[n].sym   = "m_{Q,ZL}";
   parameters[n].units = "d-1 (mg N m-3)-1";
   parameters[n].value[0] = 0.012;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZS_mQ";
   parameters[n].desc  = "Natural (quadratic) mortality rate, small zooplankton";
   parameters[n].units = "d-1 (mg N m-3)-1";
   parameters[n].sym   = "m_{Q,ZS}";
   parameters[n].value[0] = 0.020;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZL_FDG";
   parameters[n].desc  = "Fraction of growth inefficiency lost to detritus, large zoo.";
   parameters[n].units = "none";
   parameters[n].sym   = "\\gamma_{ZL}";
   parameters[n].value[0] = 0.5;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZL_FDM";
   parameters[n].desc  = "Fraction of mortality lost to detritus, large zoo.";
   parameters[n].units = "none";
   parameters[n].sym   = "N/A";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZS_FDG";
   parameters[n].desc  = "Fraction of growth inefficiency lost to detritus, small zoo.";
   parameters[n].units = "none";
   parameters[n].sym   = "\\gamma_{ZS}";
   parameters[n].value[0] = 0.5;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZS_FDM";
   parameters[n].desc  = "Fraction of mortality lost to detritus, small zooplankton";
   parameters[n].units = "none";
   parameters[n].sym   = "N/A";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Remineralisation */
   parameters[n].name  = "F_LD_RD";
@@ -1515,56 +1515,56 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].units = "none";
   parameters[n].sym   = "\\zeta_{Red}";
   parameters[n].value[0] = 0.19;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "F_LD_DOM";
   parameters[n].desc  = "Fraction of labile detritus converted to DOM";
   parameters[n].units = "none";
   parameters[n].sym   = "\\vartheta_{Red}";
   parameters[n].value[0] = 0.1;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "F_RD_DOM";
   parameters[n].desc  = "fraction of refractory detritus that breaks down to DOM";
   parameters[n].units = "none";
   parameters[n].sym   = "\\vartheta_{Ref}";
   parameters[n].value[0] = 0.05;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_DetPL";
   parameters[n].desc  = "Breakdown rate of labile detritus at 106:16:1";
   parameters[n].units = "d-1";
   parameters[n].sym   = "r_{Red}";
   parameters[n].value[0] = 0.04;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_DetBL";
   parameters[n].desc  = "Breakdown rate of labile detritus at 550:30:1";
   parameters[n].units = "d-1";
   parameters[n].sym   = "r_{Atk}";
   parameters[n].value[0] = 0.001;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_RD";
   parameters[n].desc  = "Breakdown rate of refractory detritus";
   parameters[n].units = "d-1";
   parameters[n].sym   = "r_{R}";
   parameters[n].value[0] = 0.001;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_DOM";
   parameters[n].desc  = "Breakdown rate of dissolved organic matter";
   parameters[n].units = "d-1";
   parameters[n].sym   = "r_{O}";
   parameters[n].value[0] = 0.0001;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Plank_resp";
   parameters[n].desc  = "Respiration as a fraction of umax";
   parameters[n].units = "none";
   parameters[n].sym   = "\\phi";
   parameters[n].value[0] = 0.025;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Sediment parameters */
 
@@ -1573,98 +1573,98 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].units = "mg O m-3";
   parameters[n].sym   = "K_{OA}";
   parameters[n].value[0] = 256.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_nit_wc";
   parameters[n].desc  = "Maximum nitrification rate in water column";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\tau_{nit,wc}";
   parameters[n].value[0] = 0.1;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_nit_sed";
   parameters[n].desc  = "Maximum nitrification rate in water sediment";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\tau_{nit,sed}";
   parameters[n].value[0] = 20.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "KO_nit";
   parameters[n].desc  = "Oxygen half-saturation for nitrification";
   parameters[n].units = "mg O m-3";
   parameters[n].sym   = "K_{\\mathrm{O}_2,nit}";
   parameters[n].value[0] = 500.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Pads_r";
   parameters[n].desc  = "Rate at which P reaches adsorbed/desorbed equilibrium";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\tau_{Pabs}";
   parameters[n].value[0] = 0.04;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Pads_Kwc";
   parameters[n].desc  = "Freundlich Isothermic Const P adsorption to TSS in wc";
   parameters[n].units = "mg P kg TSS-1";
   parameters[n].sym   = "k_{Pads,wc}";
   parameters[n].value[0] = 30.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Pads_Ksed";
   parameters[n].desc  = "Freundlich Isothermic Const P adsorption to TSS in sed";
   parameters[n].units = "mg P kg TSS-1";
   parameters[n].sym   = "k_{Pads,sed}";
   parameters[n].value[0] = 74.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Pads_KO";
   parameters[n].desc  = "Oxygen half-saturation for P adsorption";
   parameters[n].units = "mg O m-3";
   parameters[n].sym   = "K_{\\mathrm{O}_2,abs}";
   parameters[n].value[0] = 2000.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Pads_exp";
   parameters[n].desc  = "Exponent for Freundlich Isotherm";
   parameters[n].units = "none";
   parameters[n].sym   = "N/A";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_den";
   parameters[n].desc  = "Maximum denitrification rate";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\tau_{denit}";
   parameters[n].value[0] = 0.1;  
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "KO_den";
   parameters[n].desc  = "Oxygen half-saturation constant for denitrification";
   parameters[n].units = "mg O m-3";
   parameters[n].sym   = "K_{\\mathrm{O}_2,denit}";
   parameters[n].value[0] = 10000.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_immob_PIP";
   parameters[n].desc  = "Rate of conversion of PIP to immobilised PIP";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\tau_{Pimm}";
   parameters[n].value[0] = 0.0012;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "EpiDiffCoeff";
   parameters[n].desc  = "Sediment-water diffusion coefficient";
   parameters[n].units = "m2 s-1";
   parameters[n].sym   = "D";
   parameters[n].value[0] = 3e-7;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "EpiDiffDz";
   parameters[n].desc  = "Thickness of diffusive layer";
   parameters[n].units = "m";
   parameters[n].sym   = "h";
   parameters[n].value[0] = 0.0065;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   /* Marcroalgae */
   parameters[n].name  = "MAumax";
@@ -1672,28 +1672,28 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{MA}^{max}";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "MA_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, macroalgae";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\zeta_{MA}";
   parameters[n].value[0] = 0.01;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "MAleafden";
   parameters[n].desc  = "Nitrogen-specific leaf area of macroalgae";
   parameters[n].units = "m2 g N-1";
   parameters[n].sym   = "\\Omega_{MA}";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Benth_resp";
   parameters[n].desc  = "Respiration as a fraction of umax";
   parameters[n].units = "none";
   parameters[n].sym   = "\\phi";
   parameters[n].value[0] = 0.025;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Seagrass parameters - Zostera */
   parameters[n].name  = "SGumax";
@@ -1702,7 +1702,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\mu_{SG}^{max}";
   parameters[n].value[0] = 0.4;
   parameters[n].ref = "x2 nighttime, x2 for roots.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name  = "SG_KN";
   parameters[n].desc  = "Half-saturation of SG N uptake in SED";
@@ -1710,7 +1710,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "K_{SG,N}";
   parameters[n].value[0] = 420.0;
   parameters[n].ref = "Lee and Dunton (1999) 1204-1215. Table 3 Zostera";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SG_KP";
   parameters[n].desc  = "Half-saturation of SG P uptake in SED";
@@ -1718,7 +1718,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "K_{SG,P}";
   parameters[n].value[0] = 96.0;
   parameters[n].ref = "Gras et al. (2003) Aquatic Botany 76:299-315. Thalassia testudinum.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SG_mL";
   parameters[n].desc  = "Natural (linear) mortality rate aboveground seagrass";
@@ -1727,7 +1727,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.03;
   parameters[n].stderr = 0.001;
   parameters[n].ref = "Fourquean et al.( 2003) Chem. Ecol. 19: 373-390.Thalassia leaves with one component decay";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGROOT_mL";
   parameters[n].desc  = "Natural (linear) mortality rate belowground seagrass";
@@ -1736,7 +1736,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.004;
   parameters[n].stderr = 0.0002;
   parameters[n].ref = "Fourquean et al. (2003) Chem. Ecol. 19: 373-390. Thalassia roots with one component decay";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGfrac";
   parameters[n].desc  = "Fraction (target) of SG biomass below-ground";
@@ -1744,7 +1744,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "f_{below,SG}";
   parameters[n].value[0] = 0.75;
   parameters[n].ref = "Babcock (2015) Zostera capricornii.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGtransrate";
   parameters[n].desc  = "Time scale for seagrass translocation";
@@ -1752,7 +1752,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{tran,SG}";
   parameters[n].value[0] = 0.0333;
   parameters[n].ref = "Loosely based on Zostera marine Kaldy et al., 2013 MEPS 487:27-39";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGleafden";
   parameters[n].desc  = "Nitrogen-specific leaf area of seagrass";
@@ -1760,7 +1760,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Omega_{SG}";
   parameters[n].value[0] = 1.5;
   parameters[n].ref = "Zostera capricornia: leaf dimensions Kemp et al (1987) Mar Ecol. Prog. Ser. 41:79-86.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGseedfrac";
   parameters[n].desc  = "Seagrass seed biomass as fraction of 63 % cover";
@@ -1768,7 +1768,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "f_{seed,SG}";
   parameters[n].value[0] = 0.01;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGorient";
   parameters[n].desc  = "Sine of nadir Zostera canopy bending angle";
@@ -1776,7 +1776,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\sin \\beta_{blade,SG}";
   parameters[n].value[0] = 0.5;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGmlr";
   parameters[n].desc  = "Compensation irradiance for Zostera";
@@ -1784,7 +1784,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "E_{comp,SG}";
   parameters[n].value[0] = 4.5;
   parameters[n].ref = "Chartrand (2012) Tech report.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGrootdepth";
   parameters[n].desc  = "Maximum depth for Zostera roots";
@@ -1792,7 +1792,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "z_{root,SG}";
   parameters[n].value[0] = -0.15;
   parameters[n].ref = "Roberts (1993) Aust. J. Mar. Fresh. Res. 44:85-100.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SG_tau_critical";
   parameters[n].desc  = "Critical shear stress for SG loss";
@@ -1800,7 +1800,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{SG,shear}";
   parameters[n].value[0] = 1.0;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SG_tau_efold";
   parameters[n].desc  = "Time-scale for critical shear stress for SG loss";
@@ -1808,7 +1808,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{SG,time}";
   parameters[n].value[0] = 43200.0;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Seagrass parameters - Halophila */
   parameters[n].name  = "SGHumax";
@@ -1817,21 +1817,21 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\mu_{SGH}^{max}";
   parameters[n].value[0] = 0.4;
   parameters[n].ref = "x2 nighttime, x2 for roots.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGH_KN";
   parameters[n].desc  = "Half-saturation of SGH N uptake in SED";
   parameters[n].units = "mg N m-3";
   parameters[n].sym   = "K_{SGH,N}";
   parameters[n].value[0] = 420.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGH_KP";
   parameters[n].desc  = "Half-saturation of SGH P uptake in SED";
   parameters[n].units = "mg P m-3";
   parameters[n].sym   = "K_{SGH,P}";
   parameters[n].value[0] = 96.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHleafden";
   parameters[n].desc  = "Nitrogen-specific leaf area of SGH"; 
@@ -1839,7 +1839,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Omega_{SGH}";
   parameters[n].value[0] = 1.9;
   parameters[n].ref = "Halophila ovalis: leaf dimensions from Vermaat et al. (1995)";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGH_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, aboveground SGH";
@@ -1848,7 +1848,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.06;
   parameters[n].stderr = 0.001;
   parameters[n].ref = "Fourquean et al.(2003) Chem. Ecol. 19: 373-390.Thalassia leaves with one component decay";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHROOT_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, belowground SGH";
@@ -1857,7 +1857,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.004;
   parameters[n].stderr = 0.0002;
   parameters[n].ref = "Fourquean et al. (2003) Chem. Ecol. 19: 373-390. Thalassia roots with one component decay";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHfrac";
   parameters[n].desc  = "Fraction (target) of SGH biomass below-ground";
@@ -1865,7 +1865,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "f_{below,SGH}";
   parameters[n].value[0] = 0.5;
   parameters[n].ref = "Babcock 2015, Halophila ovalis";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHtransrate";
   parameters[n].desc  = "Time scale for Halophila translocation";
@@ -1873,7 +1873,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{tran,SGH}";
   parameters[n].value[0] = 0.0333;
   parameters[n].ref = "Loosely based on Zostera marine Kaldy et al., 2013 MEPS 487:27-39";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHseedfrac";
   parameters[n].desc  = "Halophila seed biomass as fraction of 63 % cover";
@@ -1881,7 +1881,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "f_{seed,SGH}";
   parameters[n].value[0] = 0.01;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHorient";
   parameters[n].desc  = "Sine of nadir Halophila canopy bending angle";
@@ -1889,7 +1889,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\sin \\beta_{blade,SGH}";
   parameters[n].value[0] = 1.0;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHmlr";
   parameters[n].desc  = "Compensation irradiance for Halophila";
@@ -1897,7 +1897,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "E_{comp,SGH}";
   parameters[n].value[0] = 2.0;
   parameters[n].ref = "Longstaff 2003 UQ PhD thesis";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHrootdepth";
   parameters[n].desc  = "Maximum depth for Halophila roots";
@@ -1905,7 +1905,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "z_{root,SGH}";
   parameters[n].value[0] = -0.08;
   parameters[n].ref = "Roberts (1993) Aust. J. Mar. Fresh. Res. 44:85-100.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGH_tau_critical";
   parameters[n].desc  = "Critical shear stress for SGH loss";
@@ -1913,7 +1913,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{SGH,shear}";
   parameters[n].value[0] = 1.0;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGH_tau_efold";
   parameters[n].desc  = "Time-scale for critical shear stress for SGH loss";
@@ -1921,7 +1921,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{SGH,time}";
   parameters[n].value[0] = 43200.0;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
 
   /* Seagrass parameters - Deep */
@@ -1931,21 +1931,21 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\mu_{SGD}^{max}";
   parameters[n].value[0] = 0.4;
   parameters[n].ref = "x2 nighttime, x2 for roots.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGD_KN";
   parameters[n].desc  = "Half-saturation of SGD N uptake in SED";
   parameters[n].units = "mg N m-3";
   parameters[n].sym   = "K_{SGD,N}";
   parameters[n].value[0] = 420.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGD_KP";
   parameters[n].desc  = "Half-saturation of SGD P uptake in SED";
   parameters[n].units = "mg P m-3";
   parameters[n].sym   = "K_{SGD,P}";
   parameters[n].value[0] = 96.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDleafden";
   parameters[n].desc  = "Nitrogen-specific leaf area of SGD"; 
@@ -1953,7 +1953,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Omega_{SGD}";
   parameters[n].value[0] = 1.9;
   parameters[n].ref = "Halophila ovalis: leaf dimensions from Vermaat et al. (1995)";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGD_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, aboveground SGD";
@@ -1962,7 +1962,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.06;
   parameters[n].stderr = 0.001;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDROOT_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, belowground SGD";
@@ -1971,7 +1971,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.004;
   parameters[n].stderr = 0.00002;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDfrac";
   parameters[n].desc  = "Fraction (target) of SGD biomass below-ground";
@@ -1979,7 +1979,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "f_{below,SGD}";
   parameters[n].value[0] = 0.25;
   parameters[n].ref = "Duarte (1999) Aquatic Biol. 65: 159-174, Halophila ovalis.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDtransrate";
   parameters[n].desc  = "Time scale for deep SG translocation";
@@ -1987,7 +1987,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{tran,SGD}";
   parameters[n].value[0] = 0.0333;
   parameters[n].ref = "Loosely based on Zostera marine Kaldy et al., 2013 MEPS 487:27-39";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDseedfrac";
   parameters[n].desc  = "Deep SG seed biomass as fraction of 63 % cover";
@@ -1995,7 +1995,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "f_{seed,SGD}";
   parameters[n].value[0] = 0.01;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDorient";
   parameters[n].desc  = "Sine of nadir deep SG canopy bending angle";
@@ -2003,7 +2003,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\sin \\beta_{blade,SGD}";
   parameters[n].value[0] = 1.0;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDmlr";
   parameters[n].desc  = "Compensation irradiance for deep SG";
@@ -2011,7 +2011,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "E_{comp,SGD}";
   parameters[n].value[0] = 1.5;
   parameters[n].ref = "Chartrand (2017) Tech report.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDrootdepth";
   parameters[n].desc  = "Maximum depth for deep SG roots";
@@ -2019,7 +2019,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "z_{root,SGD}";
   parameters[n].value[0] = -0.05;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGD_tau_critical";
   parameters[n].desc  = "Critical shear stress for deep SG loss";
@@ -2027,7 +2027,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{SGD,shear}";
   parameters[n].value[0] = 1.0;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGD_tau_efold";
   parameters[n].desc  = "Time-scale for shear stress for deep SG loss";
@@ -2035,7 +2035,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{SGD,time}";
   parameters[n].value[0] = 43200.0;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Corals */
   parameters[n].name  = "dissCaCO3_sed";
@@ -2043,7 +2043,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].units = "mmol C m-2 s-1";
   parameters[n].sym   = "d_{sand}";
   parameters[n].value[0] = 0.001;   // 0.007 in B1p9
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   parameters[n].ref = "Anthony et al. (2013), Biogeosciences 10:4897-4909, Fig 5E: -1 2 3 6  mmol m-2 h-1";
 
   parameters[n].name  = "CHarea";
@@ -2051,7 +2051,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].units = "m2 m-2";
   parameters[n].sym   = "A_{CH}";
   parameters[n].value[0] = 0.1;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   parameters[n].ref = "Heron Island for on 4 km model.";
 
   parameters[n].name  = "CHpolypden";
@@ -2059,49 +2059,49 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].units = "m2 g N-1";
   parameters[n].sym   = "\\Omega_{CH}";
   parameters[n].value[0] = 2.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CHumax";
   parameters[n].desc  = "Max. growth rate of Coral at Tref";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{CH}^{max}";
   parameters[n].value[0] = 0.05;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CSumax";
   parameters[n].desc  = "Max. growth rate of zooxanthellae at Tref";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{CS}^{max}";
   parameters[n].value[0] = 0.4;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CSrad";
   parameters[n].desc  = "Radius of the zooxanthellae ";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{CS}";
   parameters[n].value[0] = 5e-06;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CHmort";
   parameters[n].desc  = "Quadratic mortality rate of coral polyp ";
   parameters[n].units = "(g N m-2)-1 d-1";
   parameters[n].sym   = "\\zeta_{CH}";
   parameters[n].value[0] = 0.01;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CSmort";
   parameters[n].desc  = "Linear mortality rate of zooxanthellae ";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\zeta_{CS}";
   parameters[n].value[0] = 0.04;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CHremin";
   parameters[n].desc  = "Fraction of coral host death translocated.";
   parameters[n].units = "-";
   parameters[n].sym   = "f_{remin}";
   parameters[n].value[0] = 0.5;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Splank";
   parameters[n].desc  = "Rate coefficent for particle uptake by corals";
@@ -2109,7 +2109,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "S_{part}";
   parameters[n].value[0] = 3.0;
   parameters[n].ref = "Ribes and Atkinson (2007) Coral Reefs 26: 413-421";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "k_day_coral";
   parameters[n].desc  = "Maximum daytime coral calcification";
@@ -2117,7 +2117,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "k_{day}";
   parameters[n].value[0] = 0.0132;
   parameters[n].ref = "Anthony et al. (2013), Biogeosciences 10:4897-4909, Fig 5A: 50, 50, 35 55 mmol m-2 h-1 for Acropora aspera n=4";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "k_night_coral";
   parameters[n].desc  = "Maximum nightime coral calcification";
@@ -2125,7 +2125,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "k_{night}";
   parameters[n].value[0] = 0.0069;
   parameters[n].ref = "Anthony et al. (2013), Biogeosciences 10:4897-4909, Fig 5A: 20, 30, 20, 30  mmol m-2 h-1 for Acropora aspera n=4";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "dissCaCO3_shelf";
   parameters[n].desc  = "Carbonate sediment dissolution rate on shelf";
@@ -2133,7 +2133,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "d_{shelf}";
   parameters[n].value[0] = 0.0001;
   parameters[n].ref = "Cyronak, T. et al., LO 58:131-143. Heron Island study.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ageing_decay";
   parameters[n].desc  = "Age tracer growth rate per day";
@@ -2141,7 +2141,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "n/a";
   parameters[n].value[0] = 1.0;
   parameters[n].ref = "EMS manual";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "anti_ageing_decay";
   parameters[n].desc  = "Age tracer decay rate per day outside source";
@@ -2149,7 +2149,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Phi";
   parameters[n].value[0] = 0.1;
   parameters[n].ref = "EMS manual";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* New parameters for B3p1 */
 
@@ -2159,7 +2159,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\phi_{ROS}";
   parameters[n].value[0] = 1.418e-14;
   parameters[n].ref = "EMS manual";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Xanth_tau";
   parameters[n].desc  = "Xanthophyll switching rate coefficient";
@@ -2167,7 +2167,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{xan}";
   parameters[n].value[0] = 8.333333e-04;
   parameters[n].ref = "Gustafsson et al., 2013";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "chla2rcii";
   parameters[n].desc  = "Ratio of RCII to Chlorophyll a";
@@ -2175,7 +2175,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "A_{RCII}";
   parameters[n].value[0] = 2.238413e-06;
   parameters[n].ref = "Suggett et al., 2009";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "photon2rcii";
   parameters[n].desc  = "Stoichiometric ratio of RCII units to photons";
@@ -2183,7 +2183,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "m_{RCII}";
   parameters[n].value[0] = 0.1e-6;
   parameters[n].ref = "";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_RD_NtoP";
   parameters[n].desc  = "Scaling of DetP to DOP, relative to N";
@@ -2191,7 +2191,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "r_{RD_NtoP}";
   parameters[n].value[0] = 2.0;
   parameters[n].ref = "EMS manual";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_DOM_NtoP";
   parameters[n].desc  = "Scaling of DOM to DIP, relative to N";
@@ -2199,7 +2199,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "r_{DOM_NtoP}";
   parameters[n].value[0] = 1.5;
   parameters[n].ref = "EMS manual";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Tricho_colrad";
   parameters[n].desc  = "Radius of Trichodesmium colonies";
@@ -2207,7 +2207,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "r_{Tricho colony}";
   parameters[n].value[0] = 0.000005;
   parameters[n].ref = "EMS manual";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CS_photon2ros";
   parameters[n].desc  = "Stoichiometric coefficient of ROS";
@@ -2215,7 +2215,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "-";
   parameters[n].value[0] = 7.0e7;
   parameters[n].ref = "EMS manual";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ROSmult";
   parameters[n].desc  = "Linear coefficient of bleaching for above threshold fraction";
@@ -2223,7 +2223,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "k_{CS,ROSfrac}";
   parameters[n].value[0] = 1.0;
   parameters[n].ref = "EMS manual";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CSmaxbleachrate";
   parameters[n].desc  = "Maximum coral bleaching rate";
@@ -2231,7 +2231,7 @@ void eco_params_bgc3p1(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\zeta_{bleach}";
   parameters[n].value[0] = 1.0;
   parameters[n].ref = "EMS manual";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Assign acutal number of parameters */
   *nprm = n;
@@ -2257,7 +2257,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].units = "Deg C";
   parameters[n].value[0] = 20.0;
   parameters[n].ref = " ";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Q10";
   parameters[n].desc  = "Temperature coefficient for rate parameters";
@@ -2265,14 +2265,14 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].units = "none";
   parameters[n].value[0] = 2.0;
   parameters[n].ref = " ";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "TKEeps";
   parameters[n].desc  = "Nominal rate of TKE dissipation in water column";
   parameters[n].sym   = "\\epsilon";
   parameters[n].units = "m2 s-3";
   parameters[n].value[0] = 1.0e-6;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "xco2_in_air";
   parameters[n].desc  = "Atmospheric CO2";
@@ -2280,7 +2280,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].units = "ppmv";
   parameters[n].value[0] = 396.48;
   parameters[n].ref = "Mean 2013 at Mauna Loa: http://co2now.org/current-co2/co2-now/";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "N2";
   parameters[n].desc  = "Concentration of dissolved N2";
@@ -2288,7 +2288,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "[\\mathrm{N}_2]_{gas}";
   parameters[n].value[0] = 2000.0;
   parameters[n].ref = "Robson et al. (2013)";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Light parameters */
 
@@ -2324,7 +2324,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].value[22] = 710.0;
   parameters[n].value[23] = 800.0;
   parameters[n].ref = "Approx. 20 nm resolution with 10 nm about 440 nm. PAR (400-700) is integral of bands 6-22.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "acdom443star";
   parameters[n].desc  = "DOC-specific absorption of CDOM 443 nm";
@@ -2332,7 +2332,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "k_{CDOM,443}";
   parameters[n].value[0] = 0.00013;
   parameters[n].ref = "Based on Feb 2011 GBR satellite data and modelled DOR_C";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Phytoplankton */
 
@@ -2342,70 +2342,70 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\mu_{PL}^{max}";
   parameters[n].value[0] = 1.4;
   parameters[n].ref = " ";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PLrad";
   parameters[n].desc  = "Radius of the large phytoplankton cells";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{PL}";
   parameters[n].value[0] = 4e-06;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PhyL_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, large phytoplankton";
   parameters[n].units = "d-1";
   parameters[n].sym   = "m_{L,PL}";
   parameters[n].value[0] = 0.1;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PhyL_mL_sed";
   parameters[n].desc  = "Natural (linear) mortality rate in sediment, large phytoplankton";
   parameters[n].units = "d-1";
   parameters[n].sym   = "m_{L,PL,sed}";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PSumax";
   parameters[n].desc  = "Maximum growth rate of PS at Tref";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{PL}^{max}";
   parameters[n].value[0] = 1.6;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PSrad";
   parameters[n].desc  = "Radius of the small phytoplankton cells";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{PS}";
   parameters[n].value[0] = 1.e-06;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PhyS_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, small phytoplankton";
   parameters[n].units = "d-1";
   parameters[n].sym   = "m_{L,PS}";
   parameters[n].value[0] = 0.1;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PhyS_mL_sed";
   parameters[n].desc  = "Natural (linear) mortality rate in sediment, small phytoplankton";
   parameters[n].units = "d-1";
   parameters[n].sym   = "m_{L,PS,sed}";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "MBumax";
   parameters[n].desc  = "Maximum growth rate of MB at Tref";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{MPB}^{max}";
   parameters[n].value[0] = 0.839;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "MBrad";
   parameters[n].desc  = "Radius of the MPB cells";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{MPB}";
   parameters[n].value[0] = 1e-05;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "MPB_mQ";
   parameters[n].desc  = "Natural (quadratic) mortality rate, microphytobenthos, applied in sediment";
@@ -2413,7 +2413,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "m_{Q,MPB}";
   parameters[n].value[0] = 0.0001;
   parameters[n].ref = "At steady-state, at mu = 0.1 d-1, indep. of temp, MPB_N ~ 0.1 / MPB_mQ = 250 mg N m-3";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PSxan2chl";
   parameters[n].desc  = "Ratio of xanthophyll to chl a of PS";
@@ -2421,7 +2421,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Theta_{xan2chl,PS}";
   parameters[n].value[0] = 0.51;
   parameters[n].ref = "CSIRO parameter library: GBR region";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "PLxan2chl";
   parameters[n].desc  = "Ratio of xanthophyll to chl a of PL";
@@ -2429,7 +2429,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Theta_{xan2chl,PL}";
   parameters[n].value[0] = 0.81;
   parameters[n].ref = "CSIRO parameter library: GBR region";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "MBxan2chl";
   parameters[n].desc  = "Ratio of xanthophyll to chl a of MPB";
@@ -2437,7 +2437,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Theta_{xan2chl,MPB}";
   parameters[n].value[0] = 0.81;
   parameters[n].ref = "CSIRO parameter library: GBR region WC values";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Trichodesmium */
   parameters[n].name  = "Tricho_umax";
@@ -2445,28 +2445,28 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{MPB}^{max}";
   parameters[n].value[0] = 0.24;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Tricho_rad";
   parameters[n].desc  = "Radius of Trichodesmium colonies";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{MPB}";
   parameters[n].value[0] = 0.000005;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Tricho_Sh";
   parameters[n].desc  = "Sherwood number for the Tricho dimensionless";
   parameters[n].units = "none";
   parameters[n].sym   = "Sh_{Tricho}";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Tricho_mL";
   parameters[n].desc  = "Linear mortality for Tricho in sediment";
   parameters[n].units = "d-1";
   parameters[n].sym   = "m_{L,Tricho}";
   parameters[n].value[0] = 0.140000;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Tricho_mQ";
   parameters[n].desc  = "Quadratic mortality for Tricho due to phages in wc";
@@ -2474,14 +2474,14 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "m_{Q,Tricho}";
   parameters[n].value[0] = 0.2000;
   parameters[n].ref = "At steady-state, indep. of temp, Tricho_N ~ Tricho_umax / Tricho_mQ = 1.0 / 0.15 = 6.67 mg N m-3";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Tricho_crit";
   parameters[n].desc  = "Critical Tricho above which quadratic mortality applies";
   parameters[n].units = "mg N m-3";
   parameters[n].value[0] = 0.0002000;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "p_min";
   parameters[n].desc  = "Minimum density of Trichodesmium";
@@ -2489,7 +2489,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\rho_{min,Tricho}";
   parameters[n].value[0] = 990.000000;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "p_max";
   parameters[n].desc  = "Maximum density of Trichodesmium";
@@ -2497,7 +2497,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\rho_{max,Tricho}";
   parameters[n].value[0] = 1060.000000;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "DINcrit";
   parameters[n].desc  = "DIN conc below which Tricho N fixes ";
@@ -2505,7 +2505,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "DIN_{crit}";
   parameters[n].value[0] = 10.0;
   parameters[n].ref = "Lower end of Robson et al., (2013) 4-20 mg N m-3";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Trichoxan2chl";
   parameters[n].desc  = "Ratio of xanthophyll to chl a of Trichodesmium";
@@ -2513,7 +2513,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Theta_{xan2chl,Tricho}";
   parameters[n].value[0] = 0.5;
   parameters[n].ref = "Subramaniam (1999) LO 44:608-617. Actually redder pigment than xanthophyll.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "bphy";
   parameters[n].desc  = "Chl-specific scattering coef. for microalgae";
@@ -2521,7 +2521,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "b_{phy}";
   parameters[n].value[0] = 0.2;
   parameters[n].ref = "Typical microalgae value, Kirk (1994) Light and Photosynthesis in Aquatic ecosystems, Table 4.3";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "NtoCHL";
   parameters[n].desc  = "Nominal N:Chl a ratio in phytoplankton by weight";
@@ -2529,7 +2529,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "R_{N:Chl}";
   parameters[n].value[0] = 7;
   parameters[n].ref = "Represents a C:Chl ratio of 39.25, Baird et al. (2013) Limnol. Oceanogr. 58: 1215-1226.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "C2Chlmin";
   parameters[n].desc  = "Minimum carbon to chlorophyll a ratio";
@@ -2537,7 +2537,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\theta_{min}";
   parameters[n].value[0] = 20.0;
   parameters[n].ref = "From HPLC in Sathyendranath et al., 2009 MEPS 383,73-84";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
 
   /* Zooplankton */
@@ -2546,54 +2546,54 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{max}^{ZS}";
   parameters[n].value[0] = 4.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZSrad";
   parameters[n].desc  = "Radius of the small zooplankton cells";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{ZS}";
   parameters[n].value[0] = 5.0e-06;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZSswim";
   parameters[n].desc  = "Swimming velocity for small zooplankton";
   parameters[n].units = "m s-1";
   parameters[n].sym   = "U_{ZS}";
   parameters[n].value[0] = 2.0e-4;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZSmeth";
   parameters[n].desc  = "Grazing technique of small zooplankton";
   parameters[n].units = "none";
   parameters[n].stringvalue = "rect";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZLumax";
   parameters[n].desc  = "Maximum growth rate of ZL at Tref";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{max}^{ZL}";
   parameters[n].value[0] = 1.33;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZLrad";
   parameters[n].desc  = "Radius of the large zooplankton cells";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{ZL}";
   parameters[n].value[0] = 3.20e-04;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZLswim";
   parameters[n].desc  = "Swimming velocity for large zooplankton";
   parameters[n].units = "m s-1";
   parameters[n].sym   = "U_{ZL}";
   parameters[n].value[0] = 3.0e-3;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZLmeth";
   parameters[n].desc  = "Grazing technique of large zooplankton";
   parameters[n].units = "none";
   parameters[n].stringvalue = "rect";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZL_E";
   parameters[n].desc  = "Growth efficiency, large zooplankton";
@@ -2602,7 +2602,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.426;
   parameters[n].stderr = 0.0179;
   parameters[n].ref = "Baird and Suthers, 2007 from Hansen et al (1997) LO 42: 687-704";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZS_E";
   parameters[n].desc  = "Growth efficiency, small zooplankton";
@@ -2611,49 +2611,49 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.462;
   parameters[n].stderr = 0.0266;
   parameters[n].ref = "Baird and Suthers, 2007 from Hansen et al (1997) LO 42: 687-704";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZL_mQ";
   parameters[n].desc  = "Natural (quadratic) mortality rate, large zooplankton";
   parameters[n].sym   = "m_{Q,ZL}";
   parameters[n].units = "d-1 (mg N m-3)-1";
   parameters[n].value[0] = 0.012;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZS_mQ";
   parameters[n].desc  = "Natural (quadratic) mortality rate, small zooplankton";
   parameters[n].units = "d-1 (mg N m-3)-1";
   parameters[n].sym   = "m_{Q,ZS}";
   parameters[n].value[0] = 0.007;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZL_FDG";
   parameters[n].desc  = "Fraction of growth inefficiency lost to detritus, large zooplankton";
   parameters[n].units = "none";
   parameters[n].sym   = "\\gamma_{ZL}";
   parameters[n].value[0] = 0.5;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZL_FDM";
   parameters[n].desc  = "Fraction of mortality lost to detritus, large zooplankton";
   parameters[n].units = "none";
   parameters[n].sym   = "N/A";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZS_FDG";
   parameters[n].desc  = "Fraction of growth inefficiency lost to detritus, small zooplankton";
   parameters[n].units = "none";
   parameters[n].sym   = "\\gamma_{ZS}";
   parameters[n].value[0] = 0.5;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ZS_FDM";
   parameters[n].desc  = "Fraction of mortality lost to detritus, small zooplankton";
   parameters[n].units = "none";
   parameters[n].sym   = "N/A";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Remineralisation */
   parameters[n].name  = "F_LD_RD";
@@ -2661,56 +2661,56 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].units = "none";
   parameters[n].sym   = "\\zeta_{Red}";
   parameters[n].value[0] = 0.19;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "F_LD_DOM";
   parameters[n].desc  = "Fraction of labile detritus converted to dissolved organic matter";
   parameters[n].units = "none";
   parameters[n].sym   = "\\vartheta_{Red}";
   parameters[n].value[0] = 0.1;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "F_RD_DOM";
   parameters[n].desc  = "fraction of refractory detritus that breaks down to DOM";
   parameters[n].units = "none";
   parameters[n].sym   = "\\vartheta_{Ref}";
   parameters[n].value[0] = 0.05;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_DetPL";
   parameters[n].desc  = "Breakdown rate of labile detritus at 106:16:1";
   parameters[n].units = "d-1";
   parameters[n].sym   = "r_{Red}";
   parameters[n].value[0] = 0.04;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_DetBL";
   parameters[n].desc  = "Breakdown rate of labile detritus at 550:30:1";
   parameters[n].units = "d-1";
   parameters[n].sym   = "r_{Atk}";
   parameters[n].value[0] = 0.001;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_RD";
   parameters[n].desc  = "Breakdown rate of refractory detritus";
   parameters[n].units = "d-1";
   parameters[n].sym   = "r_{R}";
   parameters[n].value[0] = 0.001;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_DOM";
   parameters[n].desc  = "Breakdown rate of dissolved organic matter";
   parameters[n].units = "d-1";
   parameters[n].sym   = "r_{O}";
   parameters[n].value[0] = 0.0001;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Plank_resp";
   parameters[n].desc  = "Respiration as a fraction of umax";
   parameters[n].units = "none";
   parameters[n].sym   = "\\phi";
   parameters[n].value[0] = 0.025;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Sediment parameters */
 
@@ -2719,98 +2719,98 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].units = "mg O m-3";
   parameters[n].sym   = "K_{OA}";
   parameters[n].value[0] = 256.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_nit_wc";
   parameters[n].desc  = "Maximum nitrification rate in water column";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\tau_{nit,wc}";
   parameters[n].value[0] = 0.1;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_nit_sed";
   parameters[n].desc  = "Maximum nitrification rate in water sediment";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\tau_{nit,sed}";
   parameters[n].value[0] = 20.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "KO_nit";
   parameters[n].desc  = "Oxygen half-saturation for nitrification";
   parameters[n].units = "mg O m-3";
   parameters[n].sym   = "K_{\\mathrm{O}_2,nit}";
   parameters[n].value[0] = 500.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Pads_r";
   parameters[n].desc  = "Rate at which P reaches adsorbed/desorbed equilibrium";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\tau_{Pabs}";
   parameters[n].value[0] = 0.04;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Pads_Kwc";
   parameters[n].desc  = "Freundlich Isothermic Const P adsorption to TSS in water column";
   parameters[n].units = "mg P kg TSS-1";
   parameters[n].sym   = "k_{Pads,wc}";
   parameters[n].value[0] = 300.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Pads_Ksed";
   parameters[n].desc  = "Freundlich Isothermic Const P adsorption to TSS in sediment";
   parameters[n].units = "mg P kg TSS-1";
   parameters[n].sym   = "k_{Pads,sed}";
   parameters[n].value[0] = 74.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Pads_KO";
   parameters[n].desc  = "Oxygen half-saturation for P adsorption";
   parameters[n].units = "mg O m-3";
   parameters[n].sym   = "K_{\\mathrm{O}_2,abs}";
   parameters[n].value[0] = 2000.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Pads_exp";
   parameters[n].desc  = "Exponent for Freundlich Isotherm";
   parameters[n].units = "none";
   parameters[n].sym   = "N/A";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_den";
   parameters[n].desc  = "Maximum denitrification rate";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\tau_{denit}";
   parameters[n].value[0] = 5.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "KO_den";
   parameters[n].desc  = "Oxygen half-saturation constant for denitrification";
   parameters[n].units = "mg O m-3";
   parameters[n].sym   = "K_{\\mathrm{O}_2,denit}";
   parameters[n].value[0] = 10000.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "r_immob_PIP";
   parameters[n].desc  = "Rate of conversion of PIP to immobilised PIP";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\tau_{Pimm}";
   parameters[n].value[0] = 0.0012;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "EpiDiffCoeff";
   parameters[n].desc  = "Sediment-water diffusion coefficient";
   parameters[n].units = "m2 s-1";
   parameters[n].sym   = "D";
   parameters[n].value[0] = 3e-7;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "EpiDiffDz";
   parameters[n].desc  = "Thickness of diffusive layer";
   parameters[n].units = "m";
   parameters[n].sym   = "h";
   parameters[n].value[0] = 0.0065;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   /* Marcroalgae */
   parameters[n].name  = "MAumax";
@@ -2818,28 +2818,28 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{MA}^{max}";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "MA_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, macroalgae";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\zeta_{MA}";
   parameters[n].value[0] = 0.01;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "MAleafden";
   parameters[n].desc  = "Nitrogen-specific leaf area of macroalgae";
   parameters[n].units = "m2 g N-1";
   parameters[n].sym   = "\\Omega_{MA}";
   parameters[n].value[0] = 1.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Benth_resp";
   parameters[n].desc  = "Respiration as a fraction of umax";
   parameters[n].units = "none";
   parameters[n].sym   = "\\phi";
   parameters[n].value[0] = 0.025;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Seagrass parameters - Zostera */
   parameters[n].name  = "SGumax";
@@ -2848,7 +2848,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\mu_{SG}^{max}";
   parameters[n].value[0] = 0.4;
   parameters[n].ref = "x2 nighttime, x2 for roots.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name  = "SG_KN";
   parameters[n].desc  = "Half-saturation of SG N uptake in SED";
@@ -2856,7 +2856,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "K_{SG,N}";
   parameters[n].value[0] = 420.0;
   parameters[n].ref = "Lee and Dunton (1999) 1204-1215. Table 3 Zostera";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SG_KP";
   parameters[n].desc  = "Half-saturation of SG P uptake in SED";
@@ -2864,7 +2864,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "K_{SG,P}";
   parameters[n].value[0] = 96.0;
   parameters[n].ref = "Gras et al. (2003) Aquatic Botany 76:299-315. Thalassia testudinum.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SG_mL";
   parameters[n].desc  = "Natural (linear) mortality rate aboveground seagrass";
@@ -2873,7 +2873,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.04;
   parameters[n].stderr = 0.001;
   parameters[n].ref = "Fourquean et al.( 2003) Chem. Ecol. 19: 373-390.Thalassia leaves with one component decay";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGROOT_mL";
   parameters[n].desc  = "Natural (linear) mortality rate belowground seagrass";
@@ -2882,7 +2882,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.004;
   parameters[n].stderr = 0.0002;
   parameters[n].ref = "Fourquean et al. (2003) Chem. Ecol. 19: 373-390. Thalassia roots with one component decay";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGfrac";
   parameters[n].desc  = "Fraction (target) of SG biomass below-ground";
@@ -2890,7 +2890,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "f_{below,SG}";
   parameters[n].value[0] = 0.5;
   parameters[n].ref = "Duarte (1999) Aquatic Biol. 65: 159-174, Zostera capricornii.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGtransrate";
   parameters[n].desc  = "Time scale for seagrass translocation";
@@ -2898,7 +2898,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{tran,SG}";
   parameters[n].value[0] = 0.0333;
   parameters[n].ref = "Loosely based on Zostera marine Kaldy et al., 2013 MEPS 487:27-39";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGleafden";
   parameters[n].desc  = "Nitrogen-specific leaf area of seagrass";
@@ -2906,7 +2906,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Omega_{SG}";
   parameters[n].value[0] = 1.5;
   parameters[n].ref = "Zostera capricornia: leaf dimensions Kemp et al (1987) Mar Ecol. Prog. Ser. 41:79-86.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGseedfrac";
   parameters[n].desc  = "Seagrass seed biomass as fraction of 63 % cover";
@@ -2914,7 +2914,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "f_{seed,SG}";
   parameters[n].value[0] = 0.01;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGorient";
   parameters[n].desc  = "Sine of nadir Zostera canopy bending angle";
@@ -2922,7 +2922,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\sin \\beta_{blade,SG}";
   parameters[n].value[0] = 0.5;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGmlr";
   parameters[n].desc  = "Compensation irradiance for Zostera";
@@ -2930,7 +2930,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "E_{comp,SG}";
   parameters[n].value[0] = 4.5;
   parameters[n].ref = "Chartrand (2012) Tech report.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGrootdepth";
   parameters[n].desc  = "Maximum depth for Zostera roots";
@@ -2938,7 +2938,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "z_{root,SG}";
   parameters[n].value[0] = -0.15;
   parameters[n].ref = "Roberts (1993) Aust. J. Mar. Fresh. Res. 44:85-100.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
 
   /* Seagrass parameters - Halophila */
@@ -2948,21 +2948,21 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\mu_{SGH}^{max}";
   parameters[n].value[0] = 0.4;
   parameters[n].ref = "x2 nighttime, x2 for roots.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGH_KN";
   parameters[n].desc  = "Half-saturation of SGH N uptake in SED";
   parameters[n].units = "mg N m-3";
   parameters[n].sym   = "K_{SGH,N}";
   parameters[n].value[0] = 420.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGH_KP";
   parameters[n].desc  = "Half-saturation of SGH P uptake in SED";
   parameters[n].units = "mg P m-3";
   parameters[n].sym   = "K_{SGH,P}";
   parameters[n].value[0] = 96.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHleafden";
   parameters[n].desc  = "Nitrogen-specific leaf area of SGH"; 
@@ -2970,7 +2970,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Omega_{SGH}";
   parameters[n].value[0] = 1.9;
   parameters[n].ref = "Halophila ovalis: leaf dimensions from Vermaat et al. (1995)";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGH_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, aboveground SGH";
@@ -2979,7 +2979,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.08;
   parameters[n].stderr = 0.001;
   parameters[n].ref = "Fourquean et al.(2003) Chem. Ecol. 19: 373-390.Thalassia leaves with one component decay";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHROOT_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, belowground SGH";
@@ -2988,7 +2988,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.004;
   parameters[n].stderr = 0.0002;
   parameters[n].ref = "Fourquean et al. (2003) Chem. Ecol. 19: 373-390. Thalassia roots with one component decay";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHfrac";
   parameters[n].desc  = "Fraction (target) of SGH biomass below-ground";
@@ -2996,7 +2996,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "f_{below,SGH}";
   parameters[n].value[0] = 0.25;
   parameters[n].ref = "Duarte (1999) Aquatic Biol. 65: 159-174, Halophila ovalis.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHtransrate";
   parameters[n].desc  = "Time scale for seagrass translocation";
@@ -3004,7 +3004,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{tran,SGH}";
   parameters[n].value[0] = 0.0333;
   parameters[n].ref = "Loosely based on Zostera marine Kaldy et al., 2013 MEPS 487:27-39";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHseedfrac";
   parameters[n].desc  = "Halophila seed biomass as fraction of 63 % cover";
@@ -3012,7 +3012,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "f_{seed,SGH}";
   parameters[n].value[0] = 0.01;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHorient";
   parameters[n].desc  = "Sine of nadir Halophila canopy bending angle";
@@ -3020,7 +3020,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\sin \\beta_{blade,SGH}";
   parameters[n].value[0] = 1.0;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHmlr";
   parameters[n].desc  = "Compensation irradiance for Halophila";
@@ -3028,7 +3028,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "E_{comp,SGH}";
   parameters[n].value[0] = 2.8;
   parameters[n].ref = "Longstaff 2003 UQ PhD thesis";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHrootdepth";
   parameters[n].desc  = "Maximum depth for Halophila roots";
@@ -3036,7 +3036,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "z_{root,SGH}";
   parameters[n].value[0] = -0.08;
   parameters[n].ref = "Roberts (1993) Aust. J. Mar. Fresh. Res. 44:85-100.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Seagrass parameters - Deep */
 
@@ -3046,21 +3046,21 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\mu_{SGD}^{max}";
   parameters[n].value[0] = 0.4;
   parameters[n].ref = "x2 nighttime, x2 for roots.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGD_KN";
   parameters[n].desc  = "Half-saturation of SGD N uptake in SED";
   parameters[n].units = "mg N m-3";
   parameters[n].sym   = "K_{SGD,N}";
   parameters[n].value[0] = 420.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGD_KP";
   parameters[n].desc  = "Half-saturation of SGD P uptake in SED";
   parameters[n].units = "mg P m-3";
   parameters[n].sym   = "K_{SGD,P}";
   parameters[n].value[0] = 96.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDleafden";
   parameters[n].desc  = "Nitrogen-specific leaf area of SGD"; 
@@ -3068,7 +3068,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Omega_{SGD}";
   parameters[n].value[0] = 1.9;
   parameters[n].ref = "Halophila ovalis: leaf dimensions from Vermaat et al. (1995)";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGD_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, aboveground SGD";
@@ -3077,7 +3077,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.06;
   parameters[n].stderr = 0.001;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDROOT_mL";
   parameters[n].desc  = "Natural (linear) mortality rate, belowground SGD";
@@ -3086,7 +3086,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].value[0] = 0.004;
   parameters[n].stderr = 0.00002;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDfrac";
   parameters[n].desc  = "Fraction (target) of SGD biomass below-ground";
@@ -3094,7 +3094,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "f_{below,SGD}";
   parameters[n].value[0] = 0.25;
   parameters[n].ref = "Duarte (1999) Aquatic Biol. 65: 159-174, Halophila ovalis.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDtransrate";
   parameters[n].desc  = "Time scale for seagrass translocation";
@@ -3102,7 +3102,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{tran,SGD}";
   parameters[n].value[0] = 0.0333;
   parameters[n].ref = "Loosely based on Zostera marine Kaldy et al., 2013 MEPS 487:27-39";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDseedfrac";
   parameters[n].desc  = "Halophila seed biomass as fraction of 63 % cover";
@@ -3110,7 +3110,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "f_{seed,SGD}";
   parameters[n].value[0] = 0.01;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDorient";
   parameters[n].desc  = "Sine of nadir Halophila canopy bending angle";
@@ -3118,7 +3118,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\sin \\beta_{blade,SGD}";
   parameters[n].value[0] = 1.0;
   parameters[n].ref = "No source";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDmlr";
   parameters[n].desc  = "Compensation irradiance for Halophila";
@@ -3126,7 +3126,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "E_{comp,SGD}";
   parameters[n].value[0] = 1.5;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGDrootdepth";
   parameters[n].desc  = "Maximum depth for Halophila roots";
@@ -3134,7 +3134,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "z_{root,SGD}";
   parameters[n].value[0] = -0.05;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGD_tau_critical";
   parameters[n].desc  = "Critical shear stress for SGD loss";
@@ -3142,7 +3142,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{SGD,shear}";
   parameters[n].value[0] = 1.0;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGD_tau_time";
   parameters[n].desc  = "Time-scale for critical shear stress for SGD loss";
@@ -3150,7 +3150,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\tau_{SGD,time}";
   parameters[n].value[0] = 43200.0;
   parameters[n].ref = "NESP project";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Corals */
   parameters[n].name  = "dissCaCO3_sed";
@@ -3158,7 +3158,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].units = "mmol C m-2 s-1";
   parameters[n].sym   = "d_{sand}";
   parameters[n].value[0] = 0.0007;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   parameters[n].ref = "Anthony et al. (2013), Biogeosciences 10:4897-4909, Fig 5E: -1 2 3 6  mmol m-2 h-1";
 
   parameters[n].name  = "CHarea";
@@ -3166,7 +3166,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].units = "m2 m-2";
   parameters[n].sym   = "A_{CH}";
   parameters[n].value[0] = 0.1;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   parameters[n].ref = "Heron Island for on 4 km model.";
 
   parameters[n].name  = "CHpolypden";
@@ -3174,49 +3174,49 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].units = "m2 g N-1";
   parameters[n].sym   = "\\Omega_{CH}";
   parameters[n].value[0] = 2.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CHumax";
   parameters[n].desc  = "Max. growth rate of Coral at Tref";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{CH}^{max}";
   parameters[n].value[0] = 0.05;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CSumax";
   parameters[n].desc  = "Max. growth rate of zooxanthellae at Tref";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\mu_{CS}^{max}";
   parameters[n].value[0] = 0.4;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CSrad";
   parameters[n].desc  = "Radius of the zooxanthellae ";
   parameters[n].units = "m";
   parameters[n].sym   = "r_{CS}";
   parameters[n].value[0] = 5e-06;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CHmort";
   parameters[n].desc  = "Quadratic mortality rate of coral polyp ";
   parameters[n].units = "(g N m-2)-1 d-1";
   parameters[n].sym   = "\\zeta_{CH}";
   parameters[n].value[0] = 0.01;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CSmort";
   parameters[n].desc  = "Linear mortality rate of zooxanthellae ";
   parameters[n].units = "d-1";
   parameters[n].sym   = "\\zeta_{CS}";
   parameters[n].value[0] = 0.04;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CHremin";
   parameters[n].desc  = "Fraction of coral host death translocated.";
   parameters[n].units = "-";
   parameters[n].sym   = "f_{remin}";
   parameters[n].value[0] = 0.5;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "Splank";
   parameters[n].desc  = "Rate coefficent for particle uptake by corals";
@@ -3224,7 +3224,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "S_{part}";
   parameters[n].value[0] = 3.0;
   parameters[n].ref = "Ribes and Atkinson (2007) Coral Reefs 26: 413-421";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "k_day_coral";
   parameters[n].desc  = "Maximum daytime coral calcification";
@@ -3232,7 +3232,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "k_{day}";
   parameters[n].value[0] = 0.0132;
   parameters[n].ref = "Anthony et al. (2013), Biogeosciences 10:4897-4909, Fig 5A: 50, 50, 35 55 mmol m-2 h-1 for Acropora aspera n=4";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "k_night_coral";
   parameters[n].desc  = "Maximum nightime coral calcification";
@@ -3240,7 +3240,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "k_{night}";
   parameters[n].value[0] = 0.0069;
   parameters[n].ref = "Anthony et al. (2013), Biogeosciences 10:4897-4909, Fig 5A: 20, 30, 20, 30  mmol m-2 h-1 for Acropora aspera n=4";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "dissCaCO3_shelf";
   parameters[n].desc  = "Carbonate sediment dissolution rate on shelf";
@@ -3248,7 +3248,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "d_{shelf}";
   parameters[n].value[0] = 0.0001;
   parameters[n].ref = "Cyronak, T. et al., LO 58:131-143. Heron Island study.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "ageing_decay";
   parameters[n].desc  = "Age tracer growth rate per day";
@@ -3256,7 +3256,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "n/a";
   parameters[n].value[0] = 1.0;
   parameters[n].ref = "EMS manual";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "anti_ageing_decay";
   parameters[n].desc  = "Age tracer decay rate per day outside source";
@@ -3264,7 +3264,7 @@ void eco_params_gbr4(parameter_info **params, int *nprm)
   parameters[n].sym   = "\\Phi";
   parameters[n].value[0] = 0.1;
   parameters[n].ref = "EMS manual";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
 
   /* Assign acutal number of parameters */
@@ -3289,127 +3289,127 @@ void eco_params_std(parameter_info **params, int *nprm)
   parameters[n].desc  = "Growth efficiency, large zooplankton";
   parameters[n].units = "none";
   parameters[n].value[0] = 0.38;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "ZS_E";
   parameters[n].desc = "Growth efficiency, small zooplankton";
   parameters[n].units= "none";
   parameters[n].value[0] = 0.38;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "SG_KN";
   parameters[n].desc = "Half-saturation of SG N uptake in SED";
   parameters[n].units= "mg N m-3";
   parameters[n].value[0] = 5.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "SG_KP";
   parameters[n].desc = "Half-saturation of SG P uptake in SED";
   parameters[n].units= "mg N m-3";
   parameters[n].value[0] = 5.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "PhyL_mL";
   parameters[n].desc = "Natural (linear) mortality rate, large phytoplankton (in sediment)";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.14;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "PhyS_mL";
   parameters[n].desc = "Natural (linear) mortality rate, small phytoplankton (in sediment)";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.14;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "MA_mL";
   parameters[n].desc = "Natural (linear) mortality rate, macroalgae";
   parameters[n].units= "d-1";                                 
   parameters[n].value[0] = 0.01;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "SG_mL";
   parameters[n].desc = "Natural (linear) mortality rate, seagrass";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.00274;                                
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "MPB_mQ";
   parameters[n].desc = "Natural (quadratic) mortality rate, microphytobenthos";
   parameters[n].units= "d-1 (mg N m-3)-1"; 
   parameters[n].value[0] = 0.0003;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "ZL_mQ";
   parameters[n].desc = "Natural (quadratic) mortality rate, large zooplankton";
   parameters[n].units= "d-1 (mg N m-3)-1";
   parameters[n].value[0] = 0.01;                   
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "ZS_mQ";
   parameters[n].desc = "Natural (quadratic) mortality rate, small zooplankton";
   parameters[n].units= "d-1 (mg N m-3)-1";
   parameters[n].value[0] = 0.02;                    
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "ZL_FDG";
   parameters[n].desc = "Fraction of growth inefficiency lost to detritus, large zooplankton";
   parameters[n].units= "none";
   parameters[n].value[0] = 1;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "ZL_FDM";
   parameters[n].desc = "Fraction of mortality lost to detritus, large zooplankton";
   parameters[n].units= "none";
   parameters[n].value[0] = 1;                              
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "ZS_FDG";
   parameters[n].desc = "Fraction of growth inefficiency lost to detritus, small zooplankton";
   parameters[n].units= "none";
   parameters[n].value[0] = 1;                           
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "ZS_FDM";
   parameters[n].desc = "Fraction of mortality lost to detritus, small zooplankton";
   parameters[n].units= "none";
   parameters[n].value[0] = 1;                               
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "F_LD_RD";
   parameters[n].desc = "Fraction of labile detritus converted to refractory detritus";
   parameters[n].units= "none";
   parameters[n].value[0] = 0.19;                                 
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "F_LD_DOM";
   parameters[n].desc = "Fraction of labile detritus converted to dissolved organic matter";
   parameters[n].units= "none";
   parameters[n].value[0] = 0.01;                                           
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "NtoCHL";
   parameters[n].desc = "Nitrogen:Chlorophyll A ratio in phytoplankton by weight";
   parameters[n].units= "m-1";
   parameters[n].value[0] = 7;                           
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "k_w";
   parameters[n].desc = "Background light attenuation coefficient";
   parameters[n].units= "none";
   parameters[n].value[0] = 0.03;                                                                      
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "k_DOR_N";
   parameters[n].desc = "DOR_N-specific light attenuation coefficient";
   parameters[n].units= "m-1 (mg N m-3)-1";
   parameters[n].value[0] = 0.0009;                                      
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "k_DetL";
   parameters[n].desc = "Detrital N-specific light attenuation coefficient";
   parameters[n].units= "m-1 (mg N m-3)-1";
   parameters[n].value[0] = 0.0038;           
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "Light_lambda";
   parameters[n].desc = "Wavelengths of light";
@@ -3441,589 +3441,589 @@ void eco_params_std(parameter_info **params, int *nprm)
   parameters[n].value[20] = 700.0;
   parameters[n].value[21] = 720.0;
   parameters[n].value[22] = 800.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "k_TSS";
   parameters[n].desc = "TSS-specific light attenuation coefficient";
   parameters[n].units= "m-1 (kg m-3)-1";
   parameters[n].value[0] = 30.0;                                     
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "k_C_fw";
   parameters[n].desc = "CDOM attentuation coefficient of freshwater";
   parameters[n].units= "m-1";
   parameters[n].value[0] = 4.4;  
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "k_SWR_PAR";
   parameters[n].desc = "fraction of incident solar radiation that is PAR";
   parameters[n].units= "none";
   parameters[n].value[0] = 0.43;          
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "Q10";
   parameters[n].desc = "Temperature coefficient for rate parameters";
   parameters[n].units= "none";
   parameters[n].value[0] = 2.0;  
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "PLumax";
   parameters[n].desc = "Maximum growth rate of PL at Tref";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 1.75;                             
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "PLrad";
   parameters[n].desc = "Radius of the large phytoplankton cells";
   parameters[n].units= "m";
   parameters[n].value[0] = 10e-06;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "PLabsorb";
   parameters[n].desc = "Absorption coefficient of a PL cell";
   parameters[n].units= "m-1";
   parameters[n].value[0] = 50000.;             
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "PLSh";
   parameters[n].desc = "Sherwood number for the PS dimensionless";
   parameters[n].units= "none";
   parameters[n].value[0] = 1;                                
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "PLtable";
   parameters[n].desc = "Netcdf lookup table";
   parameters[n].units= "none";
   parameters[n].stringvalue = "10plkINP";                
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "PLn";
   parameters[n].desc = "Number of limiting nutrients";
   parameters[n].units= "none";
   parameters[n].value[0] = 3;                                                  
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "PSumax";
   parameters[n].desc = "Maximum growth rate of PS at Tref";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 1.25;       
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "PSrad";
   parameters[n].desc = "Radius of the small phytoplankton cells";
   parameters[n].units= "m";
   parameters[n].value[0] = 2.5e-06;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "PSabsorb";
   parameters[n].desc = "Absorption coefficient of a PS cell";
   parameters[n].units= "m-1";
   parameters[n].value[0] = 50000;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "PSSh";
   parameters[n].desc = "Sherwood number for the PL dimensionless";
   parameters[n].units= "none";
   parameters[n].value[0] = 1;                             
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "PStable";
   parameters[n].desc = "Netcdf lookup table";
   parameters[n].units= "none";
   parameters[n].stringvalue = "10plkINP";        
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "PSn";
   parameters[n].desc = "Number of limiting nutrients";
   parameters[n].units= "none";
   parameters[n].value[0] = 3;                                            
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "Tricho_aA";
   parameters[n].desc = "Nitrogen specific absorption cross-section of Tricho";
   parameters[n].units= "m2 mg N-1";
   parameters[n].value[0] = 1e-03;          
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "Tricho_mL";
   parameters[n].desc = "Linear mortality for Tricho in sediment";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.14;         
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "Tricho_mQ";
   parameters[n].desc = "Quadratic mortality for Tricho due to phages in wc"; // NEEDS ATTENTION but a rough first guess";
   parameters[n].units= "d-1 (mg N m-3)-1";
   parameters[n].value[0] = 0.015;    
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "Tricho_crit";
   parameters[n].desc = "Critical Tricho above which quadratic mortality applies";
   parameters[n].units= "mg N m-3";
   parameters[n].value[0] = 0.0;       
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "Tricho_rad";
   parameters[n].desc = "Radius of Trichodesmium colonies";
   parameters[n].units= "m";
   parameters[n].value[0] = 5.0e-06;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "Tricho_umax";
   parameters[n].desc = "Maximum growth rate of Trichodesmium at Tref";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 1.0;                            
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "p_min";
   parameters[n].desc = "Minimum density of Trichodesmium";
   parameters[n].units= "kg m-3";
   parameters[n].value[0] = 990.0;                              
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "p_max";
   parameters[n].desc = "Maximum density of Trichodesmium";
   parameters[n].units= "kg m-3";
   parameters[n].value[0] = 1060.0;                            
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "Tricho_Sh";
   parameters[n].desc = "Sherwood number for Trichodesmium";
   parameters[n].units= "none";
   parameters[n].value[0] = 1;                                    
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "N2";
   parameters[n].desc = "Concentration of dissolved N2";
   parameters[n].units= "mg N m-3";
   parameters[n].value[0] = 2e-4;                                    
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "MBumax";
   parameters[n].desc = "Maximum growth rate of MB at Tref";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.35;                                                
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "MBrad";
   parameters[n].desc = "Radius of the large phytoplankton cells";
   parameters[n].units= "m";
   parameters[n].value[0] = 1e-05;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "MBabsorb";
   parameters[n].desc = "Absorption coefficient of a MB cell";
   parameters[n].units= "m-1";
   parameters[n].value[0] = 50000;                                           
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "MBSh";
   parameters[n].desc = "Sherwood number for the PL dimensionless";
   parameters[n].units= "none";
   parameters[n].value[0] = 1;                           
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "MBtable";
   parameters[n].desc = "Netcdf lookup table";
   parameters[n].units= "none";
   parameters[n].stringvalue= "10plkINP";       
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "MBn";
   parameters[n].desc = "Number of limiting nutrients";
   parameters[n].units= "none";
   parameters[n].value[0] = 3;                                     
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "MAumax";
   parameters[n].desc = "Maximum growth rate of MA at Tref";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.02;                                            
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "MAaA";
   parameters[n].desc = "Nitrogen specific absorption cross-section of MA";
   parameters[n].units= "m2 mg N-1";
   parameters[n].value[0] = 1e-03;      
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "MAtable";
   parameters[n].desc = "Netcdf lookup table";
   parameters[n].units= "none";
   parameters[n].stringvalue = "10benINP";       
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "MAn";
   parameters[n].desc = "Number of limiting nutrients";
   parameters[n].units= "none";
   parameters[n].value[0] = 3;                                      
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "MAm";
   parameters[n].desc = "Stoichometry coefficient of Phosphorus";
   parameters[n].units= "none";
   parameters[n].value[0] = 2.4e-06;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "SGumax";
   parameters[n].desc = "Maximum growth rate of SG at Tref";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.1;                                            
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "SGaA";
   parameters[n].desc = "Nitrogen specific absorption cross-section of SG";
   parameters[n].units= "m2 mg N-1";
   parameters[n].value[0] = 1e-05;         
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "SGm";
   parameters[n].desc = "Stoichometry coefficient of Phosphorus";
   parameters[n].units= "none";
   parameters[n].value[0] = 2.4e-06;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "ZSumax";
   parameters[n].desc = "Maximum growth rate of ZS at Tref";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 3;                                               
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "ZSrad";
   parameters[n].desc = "Radius of the small zooplankton cells";
   parameters[n].units= "m-1";
   parameters[n].value[0] = 12.5e-06;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "ZSswim";
   parameters[n].desc = "Swimming velocity for small zooplankton";
   parameters[n].units= "m s-1";
   parameters[n].value[0] = 2.0e-4;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "ZSmeth";
   parameters[n].desc = "Grazing technique of small zooplankton";
   parameters[n].units= "none";
   parameters[n].stringvalue = "rect";                          
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "ZLumax";
   parameters[n].desc = "Maximum growth rate of ZL at Tref";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 1.0;                                                
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "ZLrad";
   parameters[n].desc = "Radius of the large zooplankton cells";
   parameters[n].units= "m-1";
   parameters[n].value[0] = 5.0e-04;                                             
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "ZLswim";
   parameters[n].desc = "Swimming velocity for large zooplankton";
   parameters[n].units= "m s-1";
   parameters[n].value[0] = 1.5e-3;                                                      
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "ZLmeth";
   parameters[n].desc = "Grazing technique of small zooplankton";
   parameters[n].units= "none";
   parameters[n].stringvalue = "rect";                            
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "TKEeps";
   parameters[n].desc = "TKE dissipation in water column";
   parameters[n].units= "m2s-3";
   parameters[n].value[0] = 1.0e-6;                                      
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "cf";
   parameters[n].desc = "drag coefficient of the benthic surface";
   parameters[n].units= "none";
   parameters[n].value[0] = 0.005;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
   
   parameters[n].name = "Ub";
   parameters[n].desc = "velocity at the top of the ben. bound. layer";
   parameters[n].units= "m s-1";
   parameters[n].value[0] = 0.1;    
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "ks";
   parameters[n].desc = "sand-grain roughness of the benthos";
   parameters[n].units= "m";
   parameters[n].value[0] = 0.1;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "F_RD_DOM";
   parameters[n].desc = "fraction of refractory detritus that breaks down to DOM";
   parameters[n].units= "none";
   parameters[n].value[0] = 0.05;                        
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "r_floc";
   parameters[n].desc = "rate at which TSS floculates above 10 PSU";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.01;                              
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "r_DetPL";
   parameters[n].desc = "Breakdown rate of labile detritus at 106:16:1";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.1;    
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "r_DetBL";
   parameters[n].desc = "Breakdown rate of labile detritus at 550:30:1";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.1;    
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "r_RD";
   parameters[n].desc = "Breakdown rate of refractory detritus";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.0036;                                              
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "r_DOM";
   parameters[n].desc = "Breakdown rate of dissolved organic matter";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.00176;                            
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "Tref";
   parameters[n].desc = "Reference temperature";
   parameters[n].units= "Deg C";
   parameters[n].value[0] = 15.0;                      
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "Plank_resp";
   parameters[n].desc = "Respiration as a fraction of umax";
   parameters[n].units= "none";
   parameters[n].value[0] = 0.025;                                          
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "Benth_resp";
   parameters[n].desc = "Respiration as a fraction of umax";
   parameters[n].units= "none";
   parameters[n].value[0] = 0.025;                                          
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "DFumax";
   parameters[n].desc = "Maximum growth rate of dinoflagellate at Tref";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.4;      
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "DFrad";
   parameters[n].desc = "Radius of dinoflagellate cells";
   parameters[n].units= "m";
   parameters[n].value[0] = 10.0e-6;                                    
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "DFabsorb";
   parameters[n].desc = "Absorption coefficient of a dinoflagellate cell";
   parameters[n].units= "m-1";
   parameters[n].value[0] = 40000.0;      
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "DFSh";
   parameters[n].desc = "Sherwood number for dinoflagellate";
   parameters[n].units= "none";
   parameters[n].value[0] = 1.0;                                            
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "DFn";
   parameters[n].desc = "Number of limiting nutrients for Dinoflagellate";
   parameters[n].units= "none";
   parameters[n].value[0] = 3;          
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "DFtable";
   parameters[n].desc = "Netcdf lookup table for Dinoflagellate";
   parameters[n].units= "none";
   parameters[n].stringvalue = "10plkINP";                                   
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "NOumax";
   parameters[n].desc = "Maximum growth rate of Nodularia at Tref";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.6;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "NOrad";
   parameters[n].desc = "Radius of Nodularia cells";
   parameters[n].units= "m";
   parameters[n].value[0] = 20.0e-6;                         
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "NOabsorb";
   parameters[n].desc = "Absorption coefficient of a Nodularia cell";
   parameters[n].units= "m-1";
   parameters[n].value[0] = 20000.0;                            
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "NO_TG";
   parameters[n].desc = "Temperature below which growth of Nodularia cells slows down";
   parameters[n].units= "Deg";
   parameters[n].value[0] = 19.0;                                   
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "NO_SG";
   parameters[n].desc = "Salinity above which growth of Nodularia cells slows down";
   parameters[n].units= "PSU";
   parameters[n].value[0] = 25.0;                          
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "NOSh";
   parameters[n].desc = "Sherwood number for Nodularia";
   parameters[n].units= "none";
   parameters[n].value[0] = 1.0;                                  
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "NOn";
   parameters[n].desc = "Number of limiting nutrients for Nodularia";
   parameters[n].units= "none";
   parameters[n].value[0] = 3;   
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "NOtable";
   parameters[n].desc = "NetCDF lookup table for Nodularia";
   parameters[n].units= "none";
   parameters[n].stringvalue = "10plkINP";                       
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "NO_mL";
   parameters[n].desc = "Linear mortality rate, nodularia";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.1;                                           
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "NO_mQ";
   parameters[n].desc = "Quadratic mortality rate for nodularia";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.0002;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "DFCtoNvar";
   parameters[n].desc = "Maximal to minimal C:N ratio in Dinoflagellate";
   parameters[n].units= "none";
   parameters[n].value[0] = 1.5;    
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "KO_aer";
   parameters[n].desc = "Oxygen half-saturation for aerobic respiration";
   parameters[n].units= "mg O m-3";
   parameters[n].value[0] = 500.0;  
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "r_nit_wc";
   parameters[n].desc = "Maximal nitrification rate in water column";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.1;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "r_nit_sed";
   parameters[n].desc = "Maximal nitrification rate in water sediment";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 5.0;  
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "KO_nit";
   parameters[n].desc = "Oxygen half-saturation for nitrification";
   parameters[n].units= "mg O m-3";
   parameters[n].value[0] = 500.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "Pads_r";
   parameters[n].desc = "Rate at which P reaches adsorbed/desorbed equilibrium";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.04;               
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "Pads_Kwc";
   parameters[n].desc = "Freundlich Isothermic Const P adsorption to TSS in water column";
   parameters[n].units= "mg P kg TSS-1";
   parameters[n].value[0] = 300.0;                                  
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "Pads_Ksed";
   parameters[n].desc = "Freundlich Isothermic Const P adsorption to TSS in sediment";
   parameters[n].units= "mg P kg TSS-1";
   parameters[n].value[0] = 74.0;                           
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "Pads_KO";
   parameters[n].desc = "Oxygen half-saturation for P adsorption";
   parameters[n].units= "mg O m-3";
   parameters[n].value[0] = 2000.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "Pads_exp";
   parameters[n].desc = "Exponent for Freundlich Isotherm";
   parameters[n].units= "none";
   parameters[n].value[0] = 1.0;                                      
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "PD_mL";
   parameters[n].desc = "Linear mortality for dinoflagellate in sediment";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.14;       
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "r_den";
   parameters[n].desc = "Maximum denitrification rate";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 40.0;                                
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "KO_den";
   parameters[n].desc = "Oxygen content at 50% denitrification rate";
   parameters[n].units= "mg O m-3";
   parameters[n].value[0] = 10000.0;                            
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "r_floc_sed";
   parameters[n].desc = "Rate of the TSS floculation in sediment";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.001;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "r_bury_TSS";
   parameters[n].desc = "Rate of the TSS burying";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.001;                    
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "r_immob_PIP";
   parameters[n].desc = "Rate of conversion of PIP to immobilised PIP";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.0012;                               
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "IDF";
   parameters[n].desc = "Saturation light intensity for  dinoflagellates";
   parameters[n].units= "mol photon m-2 s-1";
   parameters[n].value[0] = 1.0e-4;     
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "Fmax_Nit_sed";
   parameters[n].desc = "Maximum nitrification efficiency";
   parameters[n].units= "none";
   parameters[n].value[0] = 1.0;                                           
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "EpiDiffCoeff";
   parameters[n].desc = "Diffusion Coefficient";
   parameters[n].units= "m2s-1";
   parameters[n].value[0] = 3e-9;                     
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "EpiDiffDz";
   parameters[n].desc = "Thickness of diffusive layer";
   parameters[n].units= "m";
   parameters[n].value[0] = 0.0065;                            
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Lyngbya */
   parameters[n].name = " Phy_L_N2_pmax";
@@ -4031,91 +4031,91 @@ void eco_params_std(parameter_info **params, int *nprm)
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.6;                     
   /* observed values 0.7 to 2.5 */                                
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "Plank_L_N2_mort";
   parameters[n].desc = "Mortality rate for lyngbya";
   parameters[n].units= "d-1";
   parameters[n].value[0] = 0.0002;                          
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "Phy_L_N2_Kdin";
   parameters[n].desc = "DIN half saturation constant for lyngbya";
   parameters[n].units= "mg/L";
   /* other literature values are between 0.04 and 0.125 */
   parameters[n].value[0] = 0.03;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "Phy_L_N2_KP";
   parameters[n].desc = "DIP half saturation constant for lyngbya";
   parameters[n].units= "mg/L";
   /* other literature values are between 0.0025 and 0.02 */
   parameters[n].value[0] = 0.006;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "Phy_L_N2_alpha";
   parameters[n].desc = "initial slope of the light function (for L)"; // ie the fractional cost of fixing N and is a real value.";
   parameters[n].units= "none";
   parameters[n].value[0] = 5.7;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "Plank_L_N2_resp";
   parameters[n].desc = "respira L_N2";
   parameters[n].units= "none";
   parameters[n].value[0] = 0.01;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name = "NtoCHL_L_N2";
   parameters[n].desc = "Nitrogen:Chlorophyll A ratio in L_N2  by weight";
   parameters[n].units= "m-1";
   parameters[n].value[0] = 7;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGleafden";
   parameters[n].desc  = "Nitrogen-specific leaf area of seagrass";
   parameters[n].units = "m2 g N-1";
   parameters[n].value[0] = 4.2;
   parameters[n].ref = "Zostera capricornia: leaf dimensions Kemp et al (1987) Mar Ecol. Prog. Ser. 41:79-86.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGfrac";
   parameters[n].desc  = "Fraction (target) of SG biomass below-ground";
   parameters[n].units = "-";
   parameters[n].value[0] = 0.4790;
   parameters[n].ref = "Duarte (1999) Aquatic Biol. 65: 159-174, Zostera capricornii.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHleafden";
   parameters[n].desc  = "Nitrogen-specific leaf area of seagrass"; 
   parameters[n].units = "m2 g N-1";
   parameters[n].value[0] = 1.9;
   parameters[n].ref = "Halophila ovalis: leaf dimensions from Vermaat et al. (1995)";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "SGHfrac";
   parameters[n].desc  = "Fraction (target) of SGH biomass below-ground";
   parameters[n].units = "-";
   parameters[n].value[0] = 0.278;
   parameters[n].ref = "Duarte (1999) Aquatic Biol. 65: 159-174, Halophila ovalis.";
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "MAleafden";
   parameters[n].desc  = "Nitrogen-specific leaf area of macroalgae";
   parameters[n].units = "m2 g N-1";
   parameters[n].value[0] = 2.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CHpolypden";
   parameters[n].desc  = "Nitrogen-specific host area of coral polyp";
   parameters[n].units = "m2 g N-1";
   parameters[n].value[0] = 2.0;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   parameters[n].name  = "CSrad";
   parameters[n].desc  = "Radius of the zooxanthellae ";
   parameters[n].units = "m";
   parameters[n].value[0] = 5e-06;
-  parameters[n].index = n++;
+  parameters[n].index = n; n++;
 
   /* Assign acutal number of parameters */
   *nprm = n;


### PR DESCRIPTION
These come in two flavors:  using [n] on the lhs of an assignment
when n++ is on the rhs, and variable initializations of the form
x1 = x1 = NULL.  The former now increment n in a separate
statement.  The latter are now of the form x1 = x2 = NULL, which
fits the surrounding code.

Fixes #9 