### PR TITLE
Fix for #10 "`mrnk` uninitialized if MPI not used"

### DIFF
--- a/model/hd/momentum/vel2d.c
+++ b/model/hd/momentum/vel2d.c
@@ -243,25 +243,25 @@ void mode2d_step(geometry_t *geom,    /* Global geometry             */
 
   /*-----------------------------------------------------------------*/
   /* Initialise                                                      */
-#ifdef HAVE_MPI
   mrnk = master->mpi_rank + 1;
-  /* Only reset for the window associated with this process */
-  n = mrnk;
-#else
+
   /* Loop over all windows */
-  for (n = 1; n <= nwindows; n++) 
-#endif
-    {
-      memset(windat[n]->u1flux, 0, window[n]->sgsizS * sizeof(double));
-      memset(windat[n]->u2flux, 0, window[n]->sgsizS * sizeof(double));
-      memcpy(wincon[n]->oldeta, windat[n]->eta,
-	     window[n]->sgsizS * sizeof(double));
-      wincon[n]->neweta = wincon[n]->d4;
-      memset(wincon[n]->neweta, 0, window[n]->sgsizS * sizeof(double));
-      if (!(wincon[n]->etarlx & NONE))
-	memset(wincon[n]->eta_rlx3d, 0, window[n]->sgsizS * sizeof(double));
-      set_viscosity_2d(window[n]);
+  for( n = 1; n <= nwindows; n++){
+    if( (master->dp_mode & DP_MPI) && (n != mrnk ) ){
+	    /* If we are using MPI then only process the window
+	       associated with our rank. */
+	    continue;
     }
+    memset(windat[n]->u1flux, 0, window[n]->sgsizS * sizeof(double));
+    memset(windat[n]->u2flux, 0, window[n]->sgsizS * sizeof(double));
+    memcpy(wincon[n]->oldeta, windat[n]->eta,
+      window[n]->sgsizS * sizeof(double));
+    wincon[n]->neweta = wincon[n]->d4;
+    memset(wincon[n]->neweta, 0, window[n]->sgsizS * sizeof(double));
+    if (!(wincon[n]->etarlx & NONE))
+      memset(wincon[n]->eta_rlx3d, 0, window[n]->sgsizS * sizeof(double));
+    set_viscosity_2d(window[n]);
+  }
   /* Zero the 2D fluxes summed over the 3D step on the master if     */
   /* zoomed grids are used. These fluxes are used to adjust          */
   /* interpolated 3D velocities.                                     */


### PR DESCRIPTION
The code in question is parameterized to execute based on whether
MPI is in use or not.  The modified rank mrnk=mpi_rank+1 was
defined and used outside of an #if USE_MPI but initialized within
that guard, leading to an uninitialized variable in the non-MPI
case.

The solution implemented here gets rid of the preprocessor
defintion and instead relies on a master->dp_mode & DP_MPI
runtime check.  The code is slightly inefficient in that it will
check all the window IDs for the MPI case, but I'd argue that
we've bought significant clarity for a few thousand cpu cycles.

As this is not a trivial change I have broken it out into its own
PR.

Fixes #10 