### PR TITLE
Wmaybe-uninitialized fix for ci in advect.c

### DIFF
--- a/model/hd/momentum/advect.c
+++ b/model/hd/momentum/advect.c
@@ -7709,6 +7709,7 @@ void semi_lagrange_u2av(geometry_t *window,  /* Processing window    */
   /* Set the ghost cells */
   for (cc = 1; cc <= window->nbptS; cc++) {
     c = window->bpt[cc];
+    ci = window->bine2S[cc];
     nv[c] = 0.0;
     nu[c] = nu[ci];
     windat->u2avb[c] = 0.0;

--- a/model/hd/momentum/advect.c
+++ b/model/hd/momentum/advect.c
@@ -6304,6 +6304,7 @@ void semi_lagrange_u2(geometry_t *window,  /* Processing window      */
   /* Set the ghost cells */
   for (cc = 1; cc <= window->nbpt; cc++) {
     c = window->bpt[cc];
+    ci = window->bine2[cc];
     nv[c] = 0.0;
     nu[c] = nu[ci];
     windat->u2b[c] = 0.0;


### PR DESCRIPTION
ci is not initialized in the first for loop, but it is initialized
the same way in the next two for loops.  Based on style alone, it
appears that initialization line was inadvertently dropped from
the first for loop.  This PR restores it.

Note:  Second commit in this PR fixes an identical warning on line 7712.

Fixes #15 