### PR TITLE
Use min and max macros from standard library. Fixes csiro-coasts/ems#21

### DIFF
--- a/lib/include/emsmath.h
+++ b/lib/include/emsmath.h
@@ -19,6 +19,7 @@
 #define _EMS_MATH_H
 
 #include <limits.h>
+#include <math.h>
 
 /* Useful defines */
 #if !defined(PI)


### PR DESCRIPTION
Include <math.h> at the top of emsmath.h so that the min and max macro definitions from /usr/include/c++/12/bits/stl_algobase.h take precedence over the ones with fewer arguments defined locally

This should hopefully be enough to resolve https://github.com/csiro-coasts/EMS/issues/21